### PR TITLE
Update to support npm login --auth-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ export NPM_EMAIL=john@example.com
 npx npm-login-with-param
 ```
 
+### npm login --auth-type=legacy
+
+If you are using the `npm` CLI version 9.0 or greater and you are logging in to a private registry
+you will almost certainly need to use the `--auth-type=legacy` option of npm.
+
+See: [npm login auth-type](https://docs.npmjs.com/cli/v9/commands/npm-login#auth-type)
+
+To use `--auth-type` with this simple script, use a space and not an equal sign:
+
+``` bash
+npx npm-login-with-param --auth-type legacy --username john --password secret --email john@test.com
+```
+
 ### How it works
 
 It's a simple child process that reads/writes from/to the stdout/stdin.
+

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ args
   .option('-e, --email <email>', 'Email address')
   .option('-u, --username <username>', 'Username')
   .option('-p, --password <password>', 'Password')
+  .option('--auth-type <authType>', 'Specify npm login authentication type.')
   .option('--echo', 'Echo the values')
   .parse(process.argv);
 
@@ -35,10 +36,20 @@ if (!email) {
   process.exit(1);
 }
 
-const child = childProcess.spawn('npm', ['login', '-q'], {
+// The command line arguments we'll pass to the npm command
+// (but of course, we can't pass in the the user ID, password, or e-mail)
+const npmArgs = ['login', '-q'];
+if (args.authType) {
+  console.log(`Using --auth-type=${args.authType}`);
+  npmArgs.push(`--auth-type=${args.authType}`);
+}
+
+// Actually execute the npm install command
+const child = childProcess.spawn('npm', npmArgs, {
   stdio: ['pipe', 'pipe', 'inherit'],
 });
 
+// Intercept the UI and pass in the user name, password and e-mail when "prompted" by `npm login`
 child.stdout.on('data', d => {
   const data = d.toString();
   process.stdout.write(`${d}\n`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7527 @@
 {
   "name": "npm-login-with-param",
   "version": "1.2.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.2.1",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^2.20.0"
+      },
+      "bin": {
+        "npm-login-with-param": "index.js"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-airbnb-base": "^13.2.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.0",
+        "husky": "^2.7.0",
+        "jest-cli": "^24.9.0",
+        "prettier": "^1.18.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/core/-/core-7.6.0.tgz",
+      "integrity": "sha1-mwD3NVTt1nvryG34MD72eL49e0g=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.0",
+        "@babel/helpers": "^7.6.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/generator/-/generator-7.6.0.tgz",
+      "integrity": "sha1-4sIe+/0yk62BmiNZtEjwAr/f2lY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.6.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
+      "dev": true
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helpers/-/helpers-7.6.0.tgz",
+      "integrity": "sha1-IZYdFsajw6tZcyXDTEZcCIfTHG4=",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/parser/-/parser-7.6.0.tgz",
+      "integrity": "sha1-PgXQZHQyqDJsso0N4DiVrlpX85s=",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha1-fwFZx/UBIjDa1kzKQuyb21yVNuY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/traverse/-/traverse-7.6.0.tgz",
+      "integrity": "sha1-OJOR1RD3m+fOLd1nF75m0/7UtRY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.6.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha1-U6vzMIrdOsKiiE1TkVHFfEs6xkg=",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@cnakazawa/watch": {
+      "version": "1.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
+      "dev": true,
+      "dependencies": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "watch": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.1.95"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/console/-/console-24.9.0.tgz",
+      "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
+      "dev": true,
+      "dependencies": {
+        "@jest/source-map": "^24.9.0",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/console/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/core/-/core-24.9.0.tgz",
+      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^24.7.1",
+        "@jest/reporters": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.9.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-resolve-dependencies": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "jest-watcher": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "slash": "^2.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/core/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/environment/-/environment-24.9.0.tgz",
+      "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/reporters/-/reporters-24.9.0.tgz",
+      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "istanbul-reports": "^2.2.6",
+        "jest-haste-map": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "node-notifier": "^5.4.2",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/source-map/-/source-map-24.9.0.tgz",
+      "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-result/-/test-result-24.9.0.tgz",
+      "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/istanbul-lib-coverage": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/transform/-/transform-24.9.0.tgz",
+      "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.9.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.9.0",
+        "jest-regex-util": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "2.4.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha1-5EHqffY80IDfzQKrGZ5tFqc1/DA=",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.0.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
+      "dev": true
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "13.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs/-/yargs-13.0.2.tgz",
+      "integrity": "sha1-pkZ0/AFJV07NkLp0bpMrWl97NlM=",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "13.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha1-xWOqGS85NQodGNo2xajaOCu9gig=",
+      "dev": true
+    },
+    "node_modules/abab": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/abab/-/abab-2.0.1.tgz",
+      "integrity": "sha1-P6F3lwMrcUEOw3LhFmj0tP/IaoI=",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "4.3.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha1-n6GSat3BHJcwjE5m163Q1Awycuc=",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "6.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "node_modules/array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "dev": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.8.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "dev": true
+    },
+    "node_modules/babel-jest": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-jest/-/babel-jest-24.9.0.tgz",
+      "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.9.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.3.0",
+        "test-exclude": "^5.2.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
+      "dev": true,
+      "dependencies": {
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/base": {
+      "version": "0.11.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "dev": true,
+      "dependencies": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/base/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
+      "dev": true
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "node_modules/bser": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bser/-/bser-2.1.0.tgz",
+      "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "node_modules/cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "dev": true,
+      "dependencies": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-callsite/node_modules/callsites": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "dependencies": {
+        "caller-callsite": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
+      "dev": true,
+      "dependencies": {
+        "rsvp": "^4.8.4"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
+      "dev": true
+    },
+    "node_modules/class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "dev": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/class-utils/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
+      "integrity": "sha1-k//sH4Km4r8rw2dpzDqS+iDlAvM=",
+      "dev": true
+    },
+    "node_modules/contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "1.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssstyle/-/cssstyle-1.4.0.tgz",
+      "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
+      "dev": true,
+      "dependencies": {
+        "cssom": "0.3.x"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "7.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-7.0.0.tgz",
+      "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "2.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-property/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.14.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha1-fOEI+tgwaMh4PDzfYuUE4ITYxJc=",
+      "dev": true,
+      "dependencies": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.12.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/esprima": {
+      "version": "3.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.13.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base": {
+      "version": "13.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
+      "dev": true,
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.5",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint": "^4.19.1 || ^5.3.0",
+        "eslint-plugin-import": "^2.17.2"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
+      "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^6.0.0"
+      },
+      "bin": {
+        "eslint-config-prettier-check": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.14.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.4.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "2.x - 6.x"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 5.0.0",
+        "prettier": ">= 1.13.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exec-sh": {
+      "version": "0.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exec-sh/-/exec-sh-0.3.2.tgz",
+      "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
+      "dev": true
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-brackets/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/expect": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expect/-/expect-24.9.0.tgz",
+      "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extglob": {
+      "version": "2.0.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "dev": true,
+      "dependencies": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extglob/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "dependencies": {
+        "bser": "^2.0.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
+      "bundleDependencies": [
+        "node-pre-gyp"
+      ],
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/abbrev": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/aproba": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/are-we-there-yet": {
+      "version": "1.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/fsevents/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/chownr": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/code-point-at": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/delegates": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/fsevents/node_modules/fs-minipass": {
+      "version": "1.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/gauge": {
+      "version": "2.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/glob": {
+      "version": "7.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fsevents/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/ignore-walk": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/fsevents/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/fsevents/node_modules/inherits": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/ini": {
+      "version": "1.3.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/minimatch": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fsevents/node_modules/minimist": {
+      "version": "0.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/minipass": {
+      "version": "2.3.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/minizlib": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fsevents/node_modules/ms": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/needle": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/fsevents/node_modules/node-pre-gyp": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/fsevents/node_modules/nopt": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/fsevents/node_modules/npm-bundled": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/npm-packlist": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/npmlog": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/fsevents/node_modules/os-homedir": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/osenv": {
+      "version": "0.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/rc": {
+      "version": "1.2.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/readable-stream": {
+      "version": "2.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/fsevents/node_modules/rimraf": {
+      "version": "2.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/fsevents/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/sax": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/semver": {
+      "version": "5.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/fsevents/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/signal-exit": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/tar": {
+      "version": "4.4.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/fsevents/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/wide-align": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/fsevents/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents/node_modules/yallist": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
+      "dev": true
+    },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/has-value": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-values/node_modules/kind-of": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-4.0.0.tgz",
+      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "2.7.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/husky/-/husky-2.7.0.tgz",
+      "integrity": "sha1-wKmmo7URRiJOEbugtGu6VG5GHQU=",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "cosmiconfig": "^5.2.0",
+        "execa": "^1.0.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^7.0.0",
+        "is-ci": "^2.0.0",
+        "pkg-dir": "^4.1.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^5.1.1",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "bin": {
+        "husky-upgrade": "lib/upgrader/bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky/node_modules/get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky/node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/husky/node_modules/parse-json": {
+      "version": "5.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-5.0.0.tgz",
+      "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/import-local/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-accessor-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-data-descriptor/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-descriptor/node_modules/kind-of": {
+      "version": "5.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-5.1.0.tgz",
+      "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "node_modules/is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-cli/-/jest-cli-24.9.0.tgz",
+      "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "import-local": "^2.0.0",
+        "is-ci": "^2.0.0",
+        "jest-config": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "prompts": "^2.0.1",
+        "realpath-native": "^1.1.0",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-config/-/jest-config-24.9.0.tgz",
+      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "babel-jest": "^24.9.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "jest-environment-node": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.9.0",
+        "realpath-native": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-diff/-/jest-diff-24.9.0.tgz",
+      "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-each/-/jest-each-24.9.0.tgz",
+      "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jsdom": "^11.5.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "anymatch": "^2.0.0",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "node_modules/jest-jasmine2": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.9.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0",
+        "throat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-mock/-/jest-mock-24.9.0.tgz",
+      "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runner/-/jest-runner-24.9.0.tgz",
+      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-leak-detector": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "jest-runtime": "bin/jest-runtime.js"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-serializer": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "integrity": "sha1-5tfX75bTHouQeacUdUxdXFgojnM=",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.9.0",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.9.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-util/-/jest-util-24.9.0.tgz",
+      "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/source-map": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-util/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-validate/-/jest-validate-24.9.0.tgz",
+      "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.9.0",
+        "string-length": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+      "dev": true,
+      "dependencies": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "node_modules/jsdom": {
+      "version": "11.12.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
+      "deprecated": "use String.prototype.padStart()",
+      "dev": true
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.40.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "dev": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.14.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node_modules/node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-notifier": {
+      "version": "5.4.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
+      "dev": true,
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.1.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nwsapi/-/nwsapi-2.1.4.tgz",
+      "integrity": "sha1-4AaoeNsjY2+OimfTPKDk7fYahC8=",
+      "dev": true
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-copy/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+      "dev": true
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-each-series": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-each-series/-/p-each-series-1.0.0.tgz",
+      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "dev": true,
+      "dependencies": {
+        "p-reduce": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
+      "dev": true
+    },
+    "node_modules/pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "dev": true,
+      "dependencies": {
+        "node-modules-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
+      "dev": true,
+      "dependencies": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "node_modules/pn": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
+      "dev": true
+    },
+    "node_modules/posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "1.18.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prompts/-/prompts-2.2.1.tgz",
+      "integrity": "sha1-+QHdKi3+4IA1nA4gBZskGI11rTU=",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha1-XdJhVs22n6H9uKsZkWZ9P4DO18I=",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.9.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/react-is/-/react-is-16.9.0.tgz",
+      "integrity": "sha1-IcqVYTmarQ/xp3AcAWg+jKmB7cs=",
+      "dev": true
+    },
+    "node_modules/read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
+      "dev": true,
+      "dependencies": {
+        "util.promisify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.5.0"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request/-/request-2.88.0.tgz",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.11"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "node_modules/request/node_modules/tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.12.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "dev": true
+    },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "dependencies": {
+        "is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-node": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha1-RrULlGoqotSUeuHYhumFb9nKvl4=",
+      "dev": true,
+      "bin": {
+        "run-node": "run-node"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "node_modules/safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "dependencies": {
+        "ret": "~0.1.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/sane": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
+      "dev": true,
+      "dependencies": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "bin": {
+        "sane": "src/cli.js"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-value/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sisteransi/-/sisteransi-1.0.3.tgz",
+      "integrity": "sha1-mBaNYreeOl51jieuY8SgU9dI9Os=",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "dev": true,
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-node/node_modules/is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+      "dev": true,
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon-util/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/snapdragon/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/snapdragon/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "dependencies": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+      "dev": true
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "1.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-extend/node_modules/define-property": {
+      "version": "0.2.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+      "dev": true,
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "dependencies": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha1-bMR/DX641isPNwFhFxWjlUWR1jQ=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha1-Zp0WS+nfm291WfqOiZRbFopabFg=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude/node_modules/read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/throat": {
+      "version": "4.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-object-path/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "dev": true,
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.6.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "dev": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value": {
+      "version": "0.3.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-0.3.1.tgz",
+      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+      "dev": true,
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unset-value/node_modules/has-values": {
+      "version": "0.1.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/urix": {
+      "version": "0.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true
+    },
+    "node_modules/use": {
+      "version": "3.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+      "dev": true,
+      "dependencies": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
+      "dev": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "2.4.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/ws": {
+      "version": "5.2.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "dev": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "13.3.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0",
@@ -15,7 +7534,7 @@
     },
     "@babel/core": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/core/-/core-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/core/-/core-7.6.0.tgz",
       "integrity": "sha1-mwD3NVTt1nvryG34MD72eL49e0g=",
       "dev": true,
       "requires": {
@@ -37,7 +7556,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.5.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
           "dev": true,
           "requires": {
@@ -46,7 +7565,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -54,7 +7573,7 @@
     },
     "@babel/generator": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/generator/-/generator-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/generator/-/generator-7.6.0.tgz",
       "integrity": "sha1-4sIe+/0yk62BmiNZtEjwAr/f2lY=",
       "dev": true,
       "requires": {
@@ -67,7 +7586,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -75,7 +7594,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "requires": {
@@ -86,7 +7605,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "requires": {
@@ -95,13 +7614,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
       "dev": true
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
@@ -110,7 +7629,7 @@
     },
     "@babel/helpers": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/helpers/-/helpers-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helpers/-/helpers-7.6.0.tgz",
       "integrity": "sha1-IZYdFsajw6tZcyXDTEZcCIfTHG4=",
       "dev": true,
       "requires": {
@@ -132,13 +7651,13 @@
     },
     "@babel/parser": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/parser/-/parser-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/parser/-/parser-7.6.0.tgz",
       "integrity": "sha1-PgXQZHQyqDJsso0N4DiVrlpX85s=",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "dev": true,
       "requires": {
@@ -147,7 +7666,7 @@
     },
     "@babel/template": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/template/-/template-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha1-fwFZx/UBIjDa1kzKQuyb21yVNuY=",
       "dev": true,
       "requires": {
@@ -158,7 +7677,7 @@
     },
     "@babel/traverse": {
       "version": "7.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/traverse/-/traverse-7.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/traverse/-/traverse-7.6.0.tgz",
       "integrity": "sha1-OJOR1RD3m+fOLd1nF75m0/7UtRY=",
       "dev": true,
       "requires": {
@@ -175,7 +7694,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.5.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
           "dev": true,
           "requires": {
@@ -186,7 +7705,7 @@
     },
     "@babel/types": {
       "version": "7.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@babel/types/-/types-7.6.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/types/-/types-7.6.1.tgz",
       "integrity": "sha1-U6vzMIrdOsKiiE1TkVHFfEs6xkg=",
       "dev": true,
       "requires": {
@@ -197,25 +7716,17 @@
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@cnakazawa/watch/-/watch-1.0.3.tgz",
       "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "@jest/console": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/console/-/console-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
       "dev": true,
       "requires": {
@@ -226,7 +7737,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -234,8 +7745,8 @@
     },
     "@jest/core": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/core/-/core-24.9.0.tgz",
-      "integrity": "sha1-LOzNC5MYH5xIUOdPKprUPTUTacQ=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/core/-/core-24.9.0.tgz",
+      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
@@ -269,20 +7780,20 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -293,7 +7804,7 @@
     },
     "@jest/environment": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/environment/-/environment-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
       "dev": true,
       "requires": {
@@ -305,7 +7816,7 @@
     },
     "@jest/fake-timers": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
       "dev": true,
       "requires": {
@@ -316,8 +7827,8 @@
     },
     "@jest/reporters": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/reporters/-/reporters-24.9.0.tgz",
-      "integrity": "sha1-hmYO/44rlmHQQqjpigKLjWMaW0M=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/reporters/-/reporters-24.9.0.tgz",
+      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
       "dev": true,
       "requires": {
         "@jest/environment": "^24.9.0",
@@ -345,7 +7856,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -353,7 +7864,7 @@
     },
     "@jest/source-map": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/source-map/-/source-map-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
       "dev": true,
       "requires": {
@@ -364,7 +7875,7 @@
     },
     "@jest/test-result": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/test-result/-/test-result-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
       "dev": true,
       "requires": {
@@ -375,8 +7886,8 @@
     },
     "@jest/test-sequencer": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-      "integrity": "sha1-+PM081tiWk8vNV8v5+YDba0uazE=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
       "dev": true,
       "requires": {
         "@jest/test-result": "^24.9.0",
@@ -387,7 +7898,7 @@
     },
     "@jest/transform": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/transform/-/transform-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
       "dev": true,
       "requires": {
@@ -411,7 +7922,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -419,7 +7930,7 @@
     },
     "@jest/types": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@jest/types/-/types-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "dev": true,
       "requires": {
@@ -430,7 +7941,7 @@
     },
     "@types/babel__core": {
       "version": "7.1.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__core/-/babel__core-7.1.3.tgz",
       "integrity": "sha1-5EHqffY80IDfzQKrGZ5tFqc1/DA=",
       "dev": true,
       "requires": {
@@ -443,7 +7954,7 @@
     },
     "@types/babel__generator": {
       "version": "7.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
       "dev": true,
       "requires": {
@@ -452,7 +7963,7 @@
     },
     "@types/babel__template": {
       "version": "7.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
       "dev": true,
       "requires": {
@@ -462,7 +7973,7 @@
     },
     "@types/babel__traverse": {
       "version": "7.0.7",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
       "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
       "dev": true,
       "requires": {
@@ -471,13 +7982,13 @@
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
       "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
       "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
       "dev": true,
       "requires": {
@@ -486,7 +7997,7 @@
     },
     "@types/istanbul-reports": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
       "dev": true,
       "requires": {
@@ -496,19 +8007,19 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
       "dev": true
     },
     "@types/yargs": {
       "version": "13.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/yargs/-/yargs-13.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs/-/yargs-13.0.2.tgz",
       "integrity": "sha1-pkZ0/AFJV07NkLp0bpMrWl97NlM=",
       "dev": true,
       "requires": {
@@ -517,13 +8028,13 @@
     },
     "@types/yargs-parser": {
       "version": "13.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha1-xWOqGS85NQodGNo2xajaOCu9gig=",
       "dev": true
     },
     "abab": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/abab/-/abab-2.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/abab/-/abab-2.0.1.tgz",
       "integrity": "sha1-P6F3lwMrcUEOw3LhFmj0tP/IaoI=",
       "dev": true
     },
@@ -535,7 +8046,7 @@
     },
     "acorn-globals": {
       "version": "4.3.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha1-n6GSat3BHJcwjE5m163Q1Awycuc=",
       "dev": true,
       "requires": {
@@ -547,21 +8058,22 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -574,9 +8086,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true
     },
     "ansi-styles": {
@@ -590,7 +8102,7 @@
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/anymatch/-/anymatch-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
@@ -609,31 +8121,31 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
@@ -643,13 +8155,13 @@
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
@@ -658,13 +8170,13 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -676,37 +8188,37 @@
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/babel-jest/-/babel-jest-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "dev": true,
       "requires": {
@@ -721,7 +8233,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -729,7 +8241,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
       "dev": true,
       "requires": {
@@ -741,7 +8253,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -750,7 +8262,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -760,7 +8272,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -769,7 +8281,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -778,7 +8290,7 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         }
@@ -786,7 +8298,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "dev": true,
       "requires": {
@@ -795,7 +8307,7 @@
     },
     "babel-preset-jest": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "dev": true,
       "requires": {
@@ -811,7 +8323,7 @@
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/base/-/base-0.11.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
@@ -826,7 +8338,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -835,7 +8347,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -844,7 +8356,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -853,7 +8365,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -866,7 +8378,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -885,7 +8397,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
@@ -903,7 +8415,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -914,13 +8426,13 @@
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
       "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
       "dev": true,
       "requires": {
@@ -929,7 +8441,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -937,7 +8449,7 @@
     },
     "bser": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/bser/-/bser-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bser/-/bser-2.1.0.tgz",
       "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
       "dev": true,
       "requires": {
@@ -946,13 +8458,13 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -969,7 +8481,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -978,7 +8490,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -986,7 +8498,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -1001,13 +8513,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/capture-exit/-/capture-exit-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
       "dev": true,
       "requires": {
@@ -1016,7 +8528,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -1039,13 +8551,13 @@
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -1057,7 +8569,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1083,7 +8595,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
@@ -1093,14 +8605,14 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -1111,7 +8623,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -1122,13 +8634,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/co/-/co-4.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -1153,7 +8665,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
@@ -1167,7 +8679,7 @@
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
@@ -1179,19 +8691,19 @@
     },
     "confusing-browser-globals": {
       "version": "1.0.8",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
       "integrity": "sha1-k//sH4Km4r8rw2dpzDqS+iDlAvM=",
       "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -1200,19 +8712,19 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "requires": {
@@ -1224,7 +8736,7 @@
       "dependencies": {
         "import-fresh": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/import-fresh/-/import-fresh-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
           "requires": {
@@ -1234,7 +8746,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -1244,7 +8756,7 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -1265,13 +8777,13 @@
     },
     "cssom": {
       "version": "0.3.8",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/cssom/-/cssom-0.3.8.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
       "dev": true
     },
     "cssstyle": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/cssstyle/-/cssstyle-1.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssstyle/-/cssstyle-1.4.0.tgz",
       "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "dev": true,
       "requires": {
@@ -1280,7 +8792,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -1289,7 +8801,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "dev": true,
       "requires": {
@@ -1300,7 +8812,7 @@
       "dependencies": {
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "dev": true,
           "requires": {
@@ -1322,14 +8834,14 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "deep-is": {
@@ -1340,7 +8852,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -1349,7 +8861,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
@@ -1359,7 +8871,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -1368,7 +8880,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -1377,7 +8889,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -1390,19 +8902,19 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/diff-sequences/-/diff-sequences-24.9.0.tgz",
       "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
       "dev": true
     },
@@ -1417,7 +8929,7 @@
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "dev": true,
       "requires": {
@@ -1426,7 +8938,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -1442,7 +8954,7 @@
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
@@ -1451,7 +8963,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -1460,7 +8972,7 @@
     },
     "es-abstract": {
       "version": "1.14.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/es-abstract/-/es-abstract-1.14.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-abstract/-/es-abstract-1.14.2.tgz",
       "integrity": "sha1-fOEI+tgwaMh4PDzfYuUE4ITYxJc=",
       "dev": true,
       "requires": {
@@ -1478,7 +8990,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "requires": {
@@ -1495,7 +9007,7 @@
     },
     "escodegen": {
       "version": "1.12.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/escodegen/-/escodegen-1.12.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
       "dev": true,
       "requires": {
@@ -1508,7 +9020,7 @@
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/esprima/-/esprima-3.1.3.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
@@ -1560,7 +9072,7 @@
     },
     "eslint-config-airbnb-base": {
       "version": "13.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
       "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
       "dev": true,
       "requires": {
@@ -1580,7 +9092,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "requires": {
@@ -1590,7 +9102,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -1599,7 +9111,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1607,7 +9119,7 @@
     },
     "eslint-module-utils": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
       "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
       "dev": true,
       "requires": {
@@ -1617,7 +9129,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -1626,7 +9138,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1634,7 +9146,7 @@
     },
     "eslint-plugin-import": {
       "version": "2.18.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
       "dev": true,
       "requires": {
@@ -1653,7 +9165,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -1662,7 +9174,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -1672,7 +9184,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1761,13 +9273,13 @@
     },
     "exec-sh": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/exec-sh/-/exec-sh-0.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exec-sh/-/exec-sh-0.3.2.tgz",
       "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
       "dev": true
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
@@ -1782,13 +9294,13 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -1803,7 +9315,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -1812,7 +9324,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1821,7 +9333,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1830,7 +9342,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1838,7 +9350,7 @@
     },
     "expect": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/expect/-/expect-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expect/-/expect-24.9.0.tgz",
       "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
       "dev": true,
       "requires": {
@@ -1852,13 +9364,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -1868,7 +9380,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -1890,7 +9402,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -1906,7 +9418,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -1915,7 +9427,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1924,7 +9436,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -1933,7 +9445,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -1942,7 +9454,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -1955,14 +9467,14 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
@@ -1985,7 +9497,7 @@
     },
     "fb-watchman": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
@@ -2012,7 +9524,7 @@
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -2024,7 +9536,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2035,7 +9547,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -2061,19 +9573,19 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
@@ -2084,7 +9596,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -2099,7 +9611,7 @@
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/fsevents/-/fsevents-1.2.9.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
       "dev": true,
       "optional": true,
@@ -2566,6 +10078,15 @@
           "dev": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2575,15 +10096,6 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -2647,7 +10159,7 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
@@ -2659,7 +10171,7 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
@@ -2671,7 +10183,7 @@
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
@@ -2680,13 +10192,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -2715,37 +10227,38 @@
     },
     "graceful-fs": {
       "version": "4.2.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
       "dev": true
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.7.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       }
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
@@ -2755,7 +10268,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has/-/has-1.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -2770,13 +10283,13 @@
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -2787,7 +10300,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -2797,7 +10310,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -2807,14 +10320,14 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
+      "version": "2.8.9",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
       "dev": true,
       "requires": {
@@ -2823,7 +10336,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -2834,7 +10347,7 @@
     },
     "husky": {
       "version": "2.7.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/husky/-/husky-2.7.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/husky/-/husky-2.7.0.tgz",
       "integrity": "sha1-wKmmo7URRiJOEbugtGu6VG5GHQU=",
       "dev": true,
       "requires": {
@@ -2852,7 +10365,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -2861,13 +10374,13 @@
         },
         "get-stdin": {
           "version": "7.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/get-stdin/-/get-stdin-7.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stdin/-/get-stdin-7.0.0.tgz",
           "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY=",
           "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -2877,7 +10390,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -2886,7 +10399,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -2895,13 +10408,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "parse-json": {
           "version": "5.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/parse-json/-/parse-json-5.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
           "dev": true,
           "requires": {
@@ -2913,7 +10426,7 @@
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-4.2.0.tgz",
           "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
           "dev": true,
           "requires": {
@@ -2922,7 +10435,7 @@
           "dependencies": {
             "find-up": {
               "version": "4.1.0",
-              "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-4.1.0.tgz",
+              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-4.1.0.tgz",
               "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
               "dev": true,
               "requires": {
@@ -2932,7 +10445,7 @@
             },
             "locate-path": {
               "version": "5.0.0",
-              "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-5.0.0.tgz",
+              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-5.0.0.tgz",
               "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
               "dev": true,
               "requires": {
@@ -2941,7 +10454,7 @@
             },
             "p-locate": {
               "version": "4.1.0",
-              "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-4.1.0.tgz",
+              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-4.1.0.tgz",
               "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
               "dev": true,
               "requires": {
@@ -2950,7 +10463,7 @@
             },
             "path-exists": {
               "version": "4.0.0",
-              "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/path-exists/-/path-exists-4.0.0.tgz",
+              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-4.0.0.tgz",
               "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
               "dev": true
             }
@@ -2958,7 +10471,7 @@
         },
         "read-pkg": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/read-pkg/-/read-pkg-5.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-5.2.0.tgz",
           "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
           "dev": true,
           "requires": {
@@ -2997,7 +10510,7 @@
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/import-local/-/import-local-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
@@ -3007,7 +10520,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -3016,7 +10529,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -3026,7 +10539,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -3035,7 +10548,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -3044,13 +10557,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-3.0.0.tgz",
           "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
@@ -3103,9 +10616,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "strip-ansi": {
@@ -3121,7 +10634,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -3130,7 +10643,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3139,7 +10652,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3150,25 +10663,25 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "dev": true,
       "requires": {
@@ -3177,7 +10690,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3186,7 +10699,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3197,13 +10710,13 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
@@ -3214,7 +10727,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
@@ -3222,13 +10735,13 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
@@ -3240,13 +10753,13 @@
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -3255,7 +10768,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -3266,7 +10779,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
@@ -3281,7 +10794,7 @@
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -3290,13 +10803,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "requires": {
@@ -3305,25 +10818,25 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -3335,25 +10848,25 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "requires": {
@@ -3368,7 +10881,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -3376,7 +10889,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "requires": {
@@ -3387,7 +10900,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -3398,7 +10911,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "requires": {
@@ -3411,7 +10924,7 @@
     },
     "istanbul-reports": {
       "version": "2.2.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
       "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
       "dev": true,
       "requires": {
@@ -3420,7 +10933,7 @@
     },
     "jest-changed-files": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
       "dev": true,
       "requires": {
@@ -3431,8 +10944,8 @@
     },
     "jest-cli": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-cli/-/jest-cli-24.9.0.tgz",
-      "integrity": "sha1-rS3mLQdHLUGcarwwH8QyuYsQ0q8=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-cli/-/jest-cli-24.9.0.tgz",
+      "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
       "dev": true,
       "requires": {
         "@jest/core": "^24.9.0",
@@ -3452,8 +10965,8 @@
     },
     "jest-config": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-config/-/jest-config-24.9.0.tgz",
-      "integrity": "sha1-+xu8YMc6Rq8DWQcZ76SCXm5N0bU=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-config/-/jest-config-24.9.0.tgz",
+      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
@@ -3477,7 +10990,7 @@
     },
     "jest-diff": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-diff/-/jest-diff-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "dev": true,
       "requires": {
@@ -3489,7 +11002,7 @@
     },
     "jest-docblock": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
       "dev": true,
       "requires": {
@@ -3498,7 +11011,7 @@
     },
     "jest-each": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-each/-/jest-each-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
       "dev": true,
       "requires": {
@@ -3511,8 +11024,8 @@
     },
     "jest-environment-jsdom": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-      "integrity": "sha1-SwgGx/yU+V7bNpppzCd47sK3N1s=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
       "dev": true,
       "requires": {
         "@jest/environment": "^24.9.0",
@@ -3525,7 +11038,7 @@
     },
     "jest-environment-node": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
       "dev": true,
       "requires": {
@@ -3538,13 +11051,13 @@
     },
     "jest-get-type": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-get-type/-/jest-get-type-24.9.0.tgz",
       "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
       "dev": true
     },
     "jest-haste-map": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
       "dev": true,
       "requires": {
@@ -3564,8 +11077,8 @@
     },
     "jest-jasmine2": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-      "integrity": "sha1-H3sb0yQsF3TmKsq7NkbZavw75qA=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -3588,7 +11101,7 @@
     },
     "jest-leak-detector": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
       "dev": true,
       "requires": {
@@ -3598,7 +11111,7 @@
     },
     "jest-matcher-utils": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
       "dev": true,
       "requires": {
@@ -3610,7 +11123,7 @@
     },
     "jest-message-util": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
       "dev": true,
       "requires": {
@@ -3626,7 +11139,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -3634,7 +11147,7 @@
     },
     "jest-mock": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-mock/-/jest-mock-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
       "dev": true,
       "requires": {
@@ -3643,19 +11156,20 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
       "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
       "dev": true
     },
     "jest-resolve": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve/-/jest-resolve-24.9.0.tgz",
       "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
       "dev": true,
       "requires": {
@@ -3668,7 +11182,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
       "dev": true,
       "requires": {
@@ -3679,8 +11193,8 @@
     },
     "jest-runner": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-runner/-/jest-runner-24.9.0.tgz",
-      "integrity": "sha1-V0+v29VEVcKzS0vfQ2WiOFf830I=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runner/-/jest-runner-24.9.0.tgz",
+      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
@@ -3706,8 +11220,8 @@
     },
     "jest-runtime": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-runtime/-/jest-runtime-24.9.0.tgz",
-      "integrity": "sha1-nxRYOvak9zFKap2fAibhp4HI5Kw=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
@@ -3737,7 +11251,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -3745,13 +11259,13 @@
     },
     "jest-serializer": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha1-5tfX75bTHouQeacUdUxdXFgojnM=",
       "dev": true
     },
     "jest-snapshot": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
       "dev": true,
       "requires": {
@@ -3772,7 +11286,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -3780,7 +11294,7 @@
     },
     "jest-util": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-util/-/jest-util-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
       "dev": true,
       "requires": {
@@ -3800,7 +11314,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -3808,7 +11322,7 @@
     },
     "jest-validate": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-validate/-/jest-validate-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
       "dev": true,
       "requires": {
@@ -3822,7 +11336,7 @@
     },
     "jest-watcher": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
       "dev": true,
       "requires": {
@@ -3837,7 +11351,7 @@
     },
     "jest-worker": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jest-worker/-/jest-worker-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
       "dev": true,
       "requires": {
@@ -3847,7 +11361,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -3874,14 +11388,14 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jsdom/-/jsdom-11.12.0.tgz",
-      "integrity": "sha1-GoDUDd03ih3lllbp5txaO6hle8g=",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -3922,20 +11436,20 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3952,7 +11466,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -3963,38 +11477,38 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+      "version": "6.0.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
       "dev": true
     },
     "leven": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/leven/-/leven-3.1.0.tgz",
       "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true
     },
@@ -4010,13 +11524,13 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4028,7 +11542,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -4037,20 +11551,20 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -4059,7 +11573,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
@@ -4069,7 +11583,7 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pify/-/pify-4.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
@@ -4077,7 +11591,7 @@
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
@@ -4086,13 +11600,13 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -4101,13 +11615,13 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
@@ -4128,13 +11642,13 @@
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
       "dev": true,
       "requires": {
@@ -4148,23 +11662,23 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.8",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
@@ -4174,7 +11688,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -4184,12 +11698,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.6"
       }
     },
     "ms": {
@@ -4206,14 +11720,14 @@
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/nan/-/nan-2.14.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -4238,7 +11752,7 @@
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
@@ -4250,20 +11764,20 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha1-y3La+UyTkECY4oucWQ/YZuRkvVA=",
+      "version": "5.4.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
@@ -4275,7 +11789,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -4287,7 +11801,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -4296,7 +11810,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -4305,19 +11819,19 @@
     },
     "nwsapi": {
       "version": "2.1.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/nwsapi/-/nwsapi-2.1.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nwsapi/-/nwsapi-2.1.4.tgz",
       "integrity": "sha1-4AaoeNsjY2+OimfTPKDk7fYahC8=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -4328,7 +11842,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -4337,7 +11851,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4348,19 +11862,19 @@
     },
     "object-inspect": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object-inspect/-/object-inspect-1.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -4369,7 +11883,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
@@ -4381,7 +11895,7 @@
     },
     "object.entries": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object.entries/-/object.entries-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "dev": true,
       "requires": {
@@ -4393,7 +11907,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
@@ -4403,7 +11917,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -4412,7 +11926,7 @@
     },
     "object.values": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/object.values/-/object.values-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "requires": {
@@ -4440,24 +11954,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -4480,7 +11976,7 @@
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
@@ -4489,13 +11985,13 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-1.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
@@ -4504,7 +12000,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -4513,13 +12009,13 @@
     },
     "p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
@@ -4534,7 +12030,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -4543,19 +12039,19 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
@@ -4578,14 +12074,14 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "version": "1.0.7",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
@@ -4594,19 +12090,19 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pirates/-/pirates-4.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "dev": true,
       "requires": {
@@ -4615,7 +12111,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -4624,7 +12120,7 @@
     },
     "please-upgrade-node": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
       "dev": true,
       "requires": {
@@ -4633,13 +12129,13 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pn/-/pn-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pn/-/pn-1.1.0.tgz",
       "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -4651,7 +12147,7 @@
     },
     "prettier": {
       "version": "1.18.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/prettier/-/prettier-1.18.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
       "dev": true
     },
@@ -4666,7 +12162,7 @@
     },
     "pretty-format": {
       "version": "24.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pretty-format/-/pretty-format-24.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "dev": true,
       "requires": {
@@ -4677,9 +12173,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         }
       }
@@ -4692,7 +12188,7 @@
     },
     "prompts": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/prompts/-/prompts-2.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prompts/-/prompts-2.2.1.tgz",
       "integrity": "sha1-+QHdKi3+4IA1nA4gBZskGI11rTU=",
       "dev": true,
       "requires": {
@@ -4702,13 +12198,13 @@
     },
     "psl": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/psl/-/psl-1.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/psl/-/psl-1.4.0.tgz",
       "integrity": "sha1-XdJhVs22n6H9uKsZkWZ9P4DO18I=",
       "dev": true
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
@@ -4723,20 +12219,20 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "version": "6.5.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
     "react-is": {
       "version": "16.9.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/react-is/-/react-is-16.9.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha1-IcqVYTmarQ/xp3AcAWg+jKmB7cs=",
       "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/read-pkg/-/read-pkg-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
@@ -4747,7 +12243,7 @@
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
@@ -4757,7 +12253,7 @@
     },
     "realpath-native": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/realpath-native/-/realpath-native-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
       "dev": true,
       "requires": {
@@ -4766,7 +12262,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -4782,25 +12278,25 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/request/-/request-2.88.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "dev": true,
       "requires": {
@@ -4828,13 +12324,13 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "dev": true,
           "requires": {
@@ -4846,7 +12342,7 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "requires": {
@@ -4855,7 +12351,7 @@
     },
     "request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "dev": true,
       "requires": {
@@ -4866,19 +12362,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "resolve": {
       "version": "1.12.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve/-/resolve-1.12.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "requires": {
@@ -4887,7 +12383,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -4896,7 +12392,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -4910,7 +12406,7 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
@@ -4926,7 +12422,7 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
@@ -4941,7 +12437,7 @@
     },
     "rsvp": {
       "version": "4.8.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/rsvp/-/rsvp-4.8.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
       "dev": true
     },
@@ -4956,7 +12452,7 @@
     },
     "run-node": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/run-node/-/run-node-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/run-node/-/run-node-1.0.0.tgz",
       "integrity": "sha1-RrULlGoqotSUeuHYhumFb9nKvl4=",
       "dev": true
     },
@@ -4971,13 +12467,13 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -4992,7 +12488,7 @@
     },
     "sane": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/sane/-/sane-4.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sane/-/sane-4.1.0.tgz",
       "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
       "dev": true,
       "requires": {
@@ -5005,19 +12501,11 @@
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
         "walker": "~1.0.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
@@ -5029,19 +12517,19 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
@@ -5053,7 +12541,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5079,7 +12567,7 @@
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true
     },
@@ -5091,13 +12579,13 @@
     },
     "sisteransi": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/sisteransi/-/sisteransi-1.0.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sisteransi/-/sisteransi-1.0.3.tgz",
       "integrity": "sha1-mBaNYreeOl51jieuY8SgU9dI9Os=",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true
     },
@@ -5114,7 +12602,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -5130,7 +12618,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -5139,7 +12627,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5148,7 +12636,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -5157,13 +12645,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -5171,7 +12659,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
@@ -5182,7 +12670,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -5191,7 +12679,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -5200,7 +12688,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -5209,7 +12697,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -5222,7 +12710,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -5231,7 +12719,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5242,13 +12730,13 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
@@ -5261,7 +12749,7 @@
     },
     "source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "requires": {
@@ -5271,13 +12759,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -5287,13 +12775,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -5303,13 +12791,13 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -5324,7 +12812,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
@@ -5341,13 +12829,13 @@
     },
     "stack-utils": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/stack-utils/-/stack-utils-1.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -5357,7 +12845,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5368,13 +12856,13 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "string-length": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
@@ -5394,7 +12882,7 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha1-bMR/DX641isPNwFhFxWjlUWR1jQ=",
       "dev": true,
       "requires": {
@@ -5404,7 +12892,7 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha1-Zp0WS+nfm291WfqOiZRbFopabFg=",
       "dev": true,
       "requires": {
@@ -5414,7 +12902,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
@@ -5423,13 +12911,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -5450,7 +12938,7 @@
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
     },
@@ -5467,9 +12955,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
@@ -5496,7 +12984,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "requires": {
@@ -5508,7 +12996,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -5517,7 +13005,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -5529,7 +13017,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -5539,7 +13027,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -5548,7 +13036,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -5557,13 +13045,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -5573,7 +13061,7 @@
         },
         "path-type": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/path-type/-/path-type-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
           "dev": true,
           "requires": {
@@ -5582,13 +13070,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -5599,7 +13087,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
           "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
           "dev": true,
           "requires": {
@@ -5617,7 +13105,7 @@
     },
     "throat": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
@@ -5637,20 +13125,20 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -5659,7 +13147,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5670,7 +13158,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -5682,7 +13170,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -5692,7 +13180,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "requires": {
@@ -5702,7 +13190,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -5711,7 +13199,7 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -5723,7 +13211,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -5732,7 +13220,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
@@ -5747,13 +13235,13 @@
     },
     "type-fest": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/type-fest/-/type-fest-0.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.6.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/uglify-js/-/uglify-js-3.6.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
       "dev": true,
       "optional": true,
@@ -5764,7 +13252,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
@@ -5776,7 +13264,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -5786,7 +13274,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -5797,7 +13285,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -5808,7 +13296,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -5825,19 +13313,19 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/use/-/use-3.1.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/util.promisify/-/util.promisify-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
@@ -5847,13 +13335,13 @@
     },
     "uuid": {
       "version": "3.3.3",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/uuid/-/uuid-3.3.3.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -5863,7 +13351,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -5874,7 +13362,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
@@ -5883,7 +13371,7 @@
     },
     "walker": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
@@ -5892,13 +13380,13 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "requires": {
@@ -5907,13 +13395,13 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
@@ -5933,19 +13421,19 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
@@ -5955,14 +13443,14 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -5973,7 +13461,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -5999,7 +13487,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
       "dev": true,
       "requires": {
@@ -6009,9 +13497,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
+      "version": "5.2.3",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ws/-/ws-5.2.3.tgz",
+      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
@@ -6019,7 +13507,7 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
@@ -6031,7 +13519,7 @@
     },
     "yargs": {
       "version": "13.3.0",
-      "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/yargs/-/yargs-13.3.0.tgz",
+      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "requires": {
@@ -6048,14 +13536,14 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "4.1.1",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -6064,7 +13552,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -6074,7 +13562,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -6083,7 +13571,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -6092,13 +13580,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -6109,7 +13597,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.common.bluescape.com/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/core/-/core-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
       "integrity": "sha1-mwD3NVTt1nvryG34MD72eL49e0g=",
       "dev": true,
       "dependencies": {
@@ -60,7 +60,7 @@
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "dependencies": {
@@ -69,7 +69,7 @@
     },
     "node_modules/@babel/core/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "engines": {
@@ -78,7 +78,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/generator/-/generator-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
       "integrity": "sha1-4sIe+/0yk62BmiNZtEjwAr/f2lY=",
       "dev": true,
       "dependencies": {
@@ -91,7 +91,7 @@
     },
     "node_modules/@babel/generator/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "engines": {
@@ -100,7 +100,7 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "dependencies": {
@@ -111,7 +111,7 @@
     },
     "node_modules/@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "dependencies": {
@@ -120,13 +120,13 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
       "dev": true
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "dependencies": {
@@ -135,7 +135,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helpers/-/helpers-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
       "integrity": "sha1-IZYdFsajw6tZcyXDTEZcCIfTHG4=",
       "dev": true,
       "dependencies": {
@@ -157,7 +157,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/parser/-/parser-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
       "integrity": "sha1-PgXQZHQyqDJsso0N4DiVrlpX85s=",
       "dev": true,
       "bin": {
@@ -169,7 +169,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "dev": true,
       "dependencies": {
@@ -181,7 +181,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/template/-/template-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha1-fwFZx/UBIjDa1kzKQuyb21yVNuY=",
       "dev": true,
       "dependencies": {
@@ -192,7 +192,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/traverse/-/traverse-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
       "integrity": "sha1-OJOR1RD3m+fOLd1nF75m0/7UtRY=",
       "dev": true,
       "dependencies": {
@@ -209,7 +209,7 @@
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "dependencies": {
@@ -218,7 +218,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/types/-/types-7.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
       "integrity": "sha1-U6vzMIrdOsKiiE1TkVHFfEs6xkg=",
       "dev": true,
       "dependencies": {
@@ -229,7 +229,7 @@
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
       "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
       "dev": true,
       "dependencies": {
@@ -245,7 +245,7 @@
     },
     "node_modules/@jest/console": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/console/-/console-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
       "dev": true,
       "dependencies": {
@@ -259,7 +259,7 @@
     },
     "node_modules/@jest/console/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -268,7 +268,7 @@
     },
     "node_modules/@jest/core": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/core/-/core-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
       "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
       "dev": true,
       "dependencies": {
@@ -307,7 +307,7 @@
     },
     "node_modules/@jest/core/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -316,7 +316,7 @@
     },
     "node_modules/@jest/core/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -325,7 +325,7 @@
     },
     "node_modules/@jest/core/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "dependencies": {
@@ -337,7 +337,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/environment/-/environment-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
       "dev": true,
       "dependencies": {
@@ -352,7 +352,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
       "dev": true,
       "dependencies": {
@@ -366,7 +366,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/reporters/-/reporters-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
       "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
       "dev": true,
       "dependencies": {
@@ -398,7 +398,7 @@
     },
     "node_modules/@jest/reporters/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -407,7 +407,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/source-map/-/source-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
       "dev": true,
       "dependencies": {
@@ -421,7 +421,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-result/-/test-result-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
       "dev": true,
       "dependencies": {
@@ -435,7 +435,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
       "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
       "dev": true,
       "dependencies": {
@@ -450,7 +450,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/transform/-/transform-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
       "dev": true,
       "dependencies": {
@@ -477,7 +477,7 @@
     },
     "node_modules/@jest/transform/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -486,7 +486,7 @@
     },
     "node_modules/@jest/types": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/types/-/types-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "dev": true,
       "dependencies": {
@@ -500,7 +500,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
       "integrity": "sha1-5EHqffY80IDfzQKrGZ5tFqc1/DA=",
       "dev": true,
       "dependencies": {
@@ -513,7 +513,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
       "dev": true,
       "dependencies": {
@@ -522,7 +522,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
       "dev": true,
       "dependencies": {
@@ -532,7 +532,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
       "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
       "dev": true,
       "dependencies": {
@@ -541,13 +541,13 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
       "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
       "dev": true,
       "dependencies": {
@@ -556,7 +556,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
       "dev": true,
       "dependencies": {
@@ -566,19 +566,19 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
       "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "13.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs/-/yargs-13.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
       "integrity": "sha1-pkZ0/AFJV07NkLp0bpMrWl97NlM=",
       "dev": true,
       "dependencies": {
@@ -587,13 +587,13 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "13.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha1-xWOqGS85NQodGNo2xajaOCu9gig=",
       "dev": true
     },
     "node_modules/abab": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/abab/-/abab-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
       "integrity": "sha1-P6F3lwMrcUEOw3LhFmj0tP/IaoI=",
       "dev": true
     },
@@ -611,7 +611,7 @@
     },
     "node_modules/acorn-globals": {
       "version": "4.3.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha1-n6GSat3BHJcwjE5m163Q1Awycuc=",
       "dev": true,
       "dependencies": {
@@ -630,7 +630,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true,
       "engines": {
@@ -639,7 +639,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "dependencies": {
@@ -660,7 +660,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true,
       "engines": {
@@ -681,7 +681,7 @@
     },
     "node_modules/anymatch": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/anymatch/-/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "dependencies": {
@@ -700,7 +700,7 @@
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true,
       "engines": {
@@ -709,7 +709,7 @@
     },
     "node_modules/arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true,
       "engines": {
@@ -718,7 +718,7 @@
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true,
       "engines": {
@@ -727,13 +727,13 @@
     },
     "node_modules/array-equal": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "node_modules/array-includes": {
       "version": "3.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "dependencies": {
@@ -746,7 +746,7 @@
     },
     "node_modules/array-unique": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true,
       "engines": {
@@ -755,7 +755,7 @@
     },
     "node_modules/asn1": {
       "version": "0.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "dependencies": {
@@ -764,7 +764,7 @@
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "engines": {
@@ -773,7 +773,7 @@
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true,
       "engines": {
@@ -791,19 +791,19 @@
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true,
       "bin": {
@@ -815,7 +815,7 @@
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "engines": {
@@ -824,13 +824,13 @@
     },
     "node_modules/aws4": {
       "version": "1.8.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "node_modules/babel-jest": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-jest/-/babel-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "dev": true,
       "dependencies": {
@@ -851,7 +851,7 @@
     },
     "node_modules/babel-jest/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -860,7 +860,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
       "dev": true,
       "dependencies": {
@@ -875,7 +875,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -887,7 +887,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -900,7 +900,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/p-limit": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
       "dev": true,
       "dependencies": {
@@ -912,7 +912,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -924,7 +924,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -933,7 +933,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "dev": true,
       "dependencies": {
@@ -945,7 +945,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "dev": true,
       "dependencies": {
@@ -967,7 +967,7 @@
     },
     "node_modules/base": {
       "version": "0.11.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "dependencies": {
@@ -985,7 +985,7 @@
     },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "dependencies": {
@@ -997,7 +997,7 @@
     },
     "node_modules/base/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
       "dev": true,
       "dependencies": {
@@ -1009,7 +1009,7 @@
     },
     "node_modules/base/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
       "dev": true,
       "dependencies": {
@@ -1021,7 +1021,7 @@
     },
     "node_modules/base/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
       "dev": true,
       "dependencies": {
@@ -1035,7 +1035,7 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "dependencies": {
@@ -1054,7 +1054,7 @@
     },
     "node_modules/braces": {
       "version": "2.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "dependencies": {
@@ -1075,7 +1075,7 @@
     },
     "node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -1087,13 +1087,13 @@
     },
     "node_modules/browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
       "dev": true
     },
     "node_modules/browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
       "dev": true,
       "dependencies": {
@@ -1102,13 +1102,13 @@
     },
     "node_modules/browser-resolve/node_modules/resolve": {
       "version": "1.1.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
     "node_modules/bser": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bser/-/bser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
       "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
       "dev": true,
       "dependencies": {
@@ -1117,13 +1117,13 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "dependencies": {
@@ -1143,7 +1143,7 @@
     },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "dependencies": {
@@ -1155,7 +1155,7 @@
     },
     "node_modules/caller-callsite/node_modules/callsites": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true,
       "engines": {
@@ -1164,7 +1164,7 @@
     },
     "node_modules/caller-path": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "dependencies": {
@@ -1185,7 +1185,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
       "engines": {
@@ -1194,7 +1194,7 @@
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/capture-exit/-/capture-exit-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
       "dev": true,
       "dependencies": {
@@ -1206,7 +1206,7 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -1232,13 +1232,13 @@
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
       "dev": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "dependencies": {
@@ -1253,7 +1253,7 @@
     },
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "dependencies": {
@@ -1283,7 +1283,7 @@
     },
     "node_modules/cliui": {
       "version": "5.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "dependencies": {
@@ -1294,7 +1294,7 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -1303,7 +1303,7 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "dependencies": {
@@ -1317,7 +1317,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "dependencies": {
@@ -1329,7 +1329,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true,
       "engines": {
@@ -1339,7 +1339,7 @@
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "dependencies": {
@@ -1367,7 +1367,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "dependencies": {
@@ -1384,7 +1384,7 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
@@ -1396,13 +1396,13 @@
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
       "integrity": "sha1-k//sH4Km4r8rw2dpzDqS+iDlAvM=",
       "dev": true
     },
     "node_modules/contains-path": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true,
       "engines": {
@@ -1411,7 +1411,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "dependencies": {
@@ -1420,7 +1420,7 @@
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true,
       "engines": {
@@ -1429,13 +1429,13 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "dependencies": {
@@ -1450,7 +1450,7 @@
     },
     "node_modules/cosmiconfig/node_modules/import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-fresh/-/import-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "dependencies": {
@@ -1463,7 +1463,7 @@
     },
     "node_modules/cosmiconfig/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "dependencies": {
@@ -1476,7 +1476,7 @@
     },
     "node_modules/cosmiconfig/node_modules/resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true,
       "engines": {
@@ -1501,13 +1501,13 @@
     },
     "node_modules/cssom": {
       "version": "0.3.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssom/-/cssom-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
       "dev": true
     },
     "node_modules/cssstyle": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssstyle/-/cssstyle-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
       "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "dev": true,
       "dependencies": {
@@ -1516,7 +1516,7 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "dependencies": {
@@ -1528,7 +1528,7 @@
     },
     "node_modules/data-urls": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "dev": true,
       "dependencies": {
@@ -1539,7 +1539,7 @@
     },
     "node_modules/data-urls/node_modules/whatwg-url": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
       "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
       "dev": true,
       "dependencies": {
@@ -1560,7 +1560,7 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "engines": {
@@ -1569,7 +1569,7 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
@@ -1584,7 +1584,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "dependencies": {
@@ -1596,7 +1596,7 @@
     },
     "node_modules/define-property": {
       "version": "2.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "dependencies": {
@@ -1609,7 +1609,7 @@
     },
     "node_modules/define-property/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
       "dev": true,
       "dependencies": {
@@ -1621,7 +1621,7 @@
     },
     "node_modules/define-property/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
       "dev": true,
       "dependencies": {
@@ -1633,7 +1633,7 @@
     },
     "node_modules/define-property/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
       "dev": true,
       "dependencies": {
@@ -1647,7 +1647,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "engines": {
@@ -1656,7 +1656,7 @@
     },
     "node_modules/detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true,
       "engines": {
@@ -1665,7 +1665,7 @@
     },
     "node_modules/diff-sequences": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
       "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
       "dev": true,
       "engines": {
@@ -1686,7 +1686,7 @@
     },
     "node_modules/domexception": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "dev": true,
       "dependencies": {
@@ -1695,7 +1695,7 @@
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "dependencies": {
@@ -1711,7 +1711,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "dependencies": {
@@ -1720,7 +1720,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "dependencies": {
@@ -1729,7 +1729,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.14.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-abstract/-/es-abstract-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
       "integrity": "sha1-fOEI+tgwaMh4PDzfYuUE4ITYxJc=",
       "dev": true,
       "dependencies": {
@@ -1750,7 +1750,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "dependencies": {
@@ -1773,7 +1773,7 @@
     },
     "node_modules/escodegen": {
       "version": "1.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/escodegen/-/escodegen-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
       "dev": true,
       "dependencies": {
@@ -1795,7 +1795,7 @@
     },
     "node_modules/escodegen/node_modules/esprima": {
       "version": "3.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/esprima/-/esprima-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
       "dev": true,
       "bin": {
@@ -1858,7 +1858,7 @@
     },
     "node_modules/eslint-config-airbnb-base": {
       "version": "13.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
       "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
       "dev": true,
       "dependencies": {
@@ -1891,7 +1891,7 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "dependencies": {
@@ -1901,7 +1901,7 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -1910,13 +1910,13 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/eslint-module-utils": {
       "version": "2.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
       "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
       "dev": true,
       "dependencies": {
@@ -1929,7 +1929,7 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -1938,13 +1938,13 @@
     },
     "node_modules/eslint-module-utils/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.18.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
       "dev": true,
       "dependencies": {
@@ -1969,7 +1969,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -1978,7 +1978,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "1.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/doctrine/-/doctrine-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "dependencies": {
@@ -1991,7 +1991,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
@@ -2116,13 +2116,13 @@
     },
     "node_modules/exec-sh": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exec-sh/-/exec-sh-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
       "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
       "dev": true
     },
     "node_modules/execa": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "dependencies": {
@@ -2140,7 +2140,7 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true,
       "engines": {
@@ -2149,7 +2149,7 @@
     },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "dependencies": {
@@ -2167,7 +2167,7 @@
     },
     "node_modules/expand-brackets/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -2176,7 +2176,7 @@
     },
     "node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "dependencies": {
@@ -2188,7 +2188,7 @@
     },
     "node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -2200,13 +2200,13 @@
     },
     "node_modules/expand-brackets/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/expect": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expect/-/expect-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
       "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
       "dev": true,
       "dependencies": {
@@ -2223,13 +2223,13 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "dependencies": {
@@ -2242,7 +2242,7 @@
     },
     "node_modules/extend-shallow/node_modules/is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "dev": true,
       "dependencies": {
@@ -2268,7 +2268,7 @@
     },
     "node_modules/extglob": {
       "version": "2.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "dependencies": {
@@ -2287,7 +2287,7 @@
     },
     "node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "dependencies": {
@@ -2299,7 +2299,7 @@
     },
     "node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -2311,7 +2311,7 @@
     },
     "node_modules/extglob/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
       "dev": true,
       "dependencies": {
@@ -2323,7 +2323,7 @@
     },
     "node_modules/extglob/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
       "dev": true,
       "dependencies": {
@@ -2335,7 +2335,7 @@
     },
     "node_modules/extglob/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
       "dev": true,
       "dependencies": {
@@ -2349,7 +2349,7 @@
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true,
       "engines": [
@@ -2358,7 +2358,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
@@ -2382,7 +2382,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "dependencies": {
@@ -2415,7 +2415,7 @@
     },
     "node_modules/fill-range": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "dependencies": {
@@ -2430,7 +2430,7 @@
     },
     "node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -2442,7 +2442,7 @@
     },
     "node_modules/find-up": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "dependencies": {
@@ -2474,7 +2474,7 @@
     },
     "node_modules/for-in": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true,
       "engines": {
@@ -2483,7 +2483,7 @@
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "engines": {
@@ -2492,7 +2492,7 @@
     },
     "node_modules/form-data": {
       "version": "2.3.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "dependencies": {
@@ -2506,7 +2506,7 @@
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "dependencies": {
@@ -2524,7 +2524,7 @@
     },
     "node_modules/fsevents": {
       "version": "1.2.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fsevents/-/fsevents-1.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
       "bundleDependencies": [
         "node-pre-gyp"
@@ -3223,7 +3223,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
@@ -3235,7 +3235,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "engines": {
@@ -3253,7 +3253,7 @@
     },
     "node_modules/get-stream": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "dependencies": {
@@ -3265,7 +3265,7 @@
     },
     "node_modules/get-value": {
       "version": "2.0.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true,
       "engines": {
@@ -3274,7 +3274,7 @@
     },
     "node_modules/getpass": {
       "version": "0.1.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "dependencies": {
@@ -3309,19 +3309,19 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
       "dev": true
     },
     "node_modules/growly": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/handlebars/-/handlebars-4.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "dependencies": {
@@ -3342,7 +3342,7 @@
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
       "engines": {
@@ -3351,7 +3351,7 @@
     },
     "node_modules/har-validator": {
       "version": "5.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "deprecated": "this library is no longer supported",
       "dev": true,
@@ -3365,7 +3365,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has/-/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "dependencies": {
@@ -3386,7 +3386,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true,
       "engines": {
@@ -3395,7 +3395,7 @@
     },
     "node_modules/has-value": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "dependencies": {
@@ -3409,7 +3409,7 @@
     },
     "node_modules/has-values": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "dependencies": {
@@ -3422,7 +3422,7 @@
     },
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
       "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
       "dev": true,
       "dependencies": {
@@ -3434,13 +3434,13 @@
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
       "dev": true,
       "dependencies": {
@@ -3449,7 +3449,7 @@
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "dependencies": {
@@ -3464,7 +3464,7 @@
     },
     "node_modules/husky": {
       "version": "2.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/husky/-/husky-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-2.7.0.tgz",
       "integrity": "sha1-wKmmo7URRiJOEbugtGu6VG5GHQU=",
       "dev": true,
       "hasInstallScript": true,
@@ -3489,7 +3489,7 @@
     },
     "node_modules/husky/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -3501,7 +3501,7 @@
     },
     "node_modules/husky/node_modules/get-stdin": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stdin/-/get-stdin-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
       "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY=",
       "dev": true,
       "engines": {
@@ -3510,7 +3510,7 @@
     },
     "node_modules/husky/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -3523,7 +3523,7 @@
     },
     "node_modules/husky/node_modules/p-limit": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
       "dev": true,
       "dependencies": {
@@ -3535,7 +3535,7 @@
     },
     "node_modules/husky/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -3547,7 +3547,7 @@
     },
     "node_modules/husky/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -3556,7 +3556,7 @@
     },
     "node_modules/husky/node_modules/parse-json": {
       "version": "5.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
       "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
       "dev": true,
       "dependencies": {
@@ -3571,7 +3571,7 @@
     },
     "node_modules/husky/node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "dependencies": {
@@ -3583,7 +3583,7 @@
     },
     "node_modules/husky/node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
       "dev": true,
       "dependencies": {
@@ -3596,7 +3596,7 @@
     },
     "node_modules/husky/node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
       "dev": true,
       "dependencies": {
@@ -3608,7 +3608,7 @@
     },
     "node_modules/husky/node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
       "dev": true,
       "dependencies": {
@@ -3620,7 +3620,7 @@
     },
     "node_modules/husky/node_modules/pkg-dir/node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "engines": {
@@ -3629,7 +3629,7 @@
     },
     "node_modules/husky/node_modules/read-pkg": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "dev": true,
       "dependencies": {
@@ -3678,7 +3678,7 @@
     },
     "node_modules/import-local": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-local/-/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "dependencies": {
@@ -3694,7 +3694,7 @@
     },
     "node_modules/import-local/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -3706,7 +3706,7 @@
     },
     "node_modules/import-local/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -3719,7 +3719,7 @@
     },
     "node_modules/import-local/node_modules/p-limit": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
       "dev": true,
       "dependencies": {
@@ -3731,7 +3731,7 @@
     },
     "node_modules/import-local/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -3743,7 +3743,7 @@
     },
     "node_modules/import-local/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -3752,7 +3752,7 @@
     },
     "node_modules/import-local/node_modules/pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "dev": true,
       "dependencies": {
@@ -3813,7 +3813,7 @@
     },
     "node_modules/inquirer/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -3834,7 +3834,7 @@
     },
     "node_modules/invariant": {
       "version": "2.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "dependencies": {
@@ -3843,7 +3843,7 @@
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "dependencies": {
@@ -3855,7 +3855,7 @@
     },
     "node_modules/is-accessor-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -3867,19 +3867,19 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "node_modules/is-callable": {
       "version": "1.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true,
       "engines": {
@@ -3888,7 +3888,7 @@
     },
     "node_modules/is-ci": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "dev": true,
       "dependencies": {
@@ -3900,7 +3900,7 @@
     },
     "node_modules/is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "dependencies": {
@@ -3912,7 +3912,7 @@
     },
     "node_modules/is-data-descriptor/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -3924,7 +3924,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true,
       "engines": {
@@ -3933,7 +3933,7 @@
     },
     "node_modules/is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "dependencies": {
@@ -3947,7 +3947,7 @@
     },
     "node_modules/is-descriptor/node_modules/kind-of": {
       "version": "5.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
       "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
       "dev": true,
       "engines": {
@@ -3956,7 +3956,7 @@
     },
     "node_modules/is-directory": {
       "version": "0.3.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true,
       "engines": {
@@ -3965,7 +3965,7 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true,
       "engines": {
@@ -3983,7 +3983,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true,
       "engines": {
@@ -3992,7 +3992,7 @@
     },
     "node_modules/is-number": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "dependencies": {
@@ -4004,7 +4004,7 @@
     },
     "node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -4016,7 +4016,7 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "dependencies": {
@@ -4034,7 +4034,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "dependencies": {
@@ -4046,7 +4046,7 @@
     },
     "node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "engines": {
@@ -4055,7 +4055,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "dependencies": {
@@ -4067,13 +4067,13 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true,
       "engines": {
@@ -4082,7 +4082,7 @@
     },
     "node_modules/is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true,
       "engines": {
@@ -4091,7 +4091,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -4103,7 +4103,7 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "engines": {
@@ -4112,13 +4112,13 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true,
       "engines": {
@@ -4127,7 +4127,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "dependencies": {
@@ -4145,7 +4145,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "6.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true,
       "bin": {
@@ -4154,7 +4154,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "dependencies": {
@@ -4168,7 +4168,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
       "dev": true,
       "dependencies": {
@@ -4180,7 +4180,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "dependencies": {
@@ -4196,7 +4196,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "2.2.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
       "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
       "dev": true,
       "dependencies": {
@@ -4208,7 +4208,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
       "dev": true,
       "dependencies": {
@@ -4222,7 +4222,7 @@
     },
     "node_modules/jest-cli": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-cli/-/jest-cli-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
       "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
       "dev": true,
       "dependencies": {
@@ -4249,7 +4249,7 @@
     },
     "node_modules/jest-config": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-config/-/jest-config-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
       "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
       "dev": true,
       "dependencies": {
@@ -4277,7 +4277,7 @@
     },
     "node_modules/jest-diff": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-diff/-/jest-diff-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "dev": true,
       "dependencies": {
@@ -4292,7 +4292,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
       "dev": true,
       "dependencies": {
@@ -4304,7 +4304,7 @@
     },
     "node_modules/jest-each": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-each/-/jest-each-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
       "dev": true,
       "dependencies": {
@@ -4320,7 +4320,7 @@
     },
     "node_modules/jest-environment-jsdom": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
       "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
       "dev": true,
       "dependencies": {
@@ -4337,7 +4337,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
       "dev": true,
       "dependencies": {
@@ -4353,7 +4353,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
       "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
       "dev": true,
       "engines": {
@@ -4362,7 +4362,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
       "dev": true,
       "dependencies": {
@@ -4387,7 +4387,7 @@
     },
     "node_modules/jest-jasmine2": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
       "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
       "dev": true,
       "dependencies": {
@@ -4414,7 +4414,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
       "dev": true,
       "dependencies": {
@@ -4427,7 +4427,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
       "dev": true,
       "dependencies": {
@@ -4442,7 +4442,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
       "dev": true,
       "dependencies": {
@@ -4461,7 +4461,7 @@
     },
     "node_modules/jest-message-util/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -4470,7 +4470,7 @@
     },
     "node_modules/jest-mock": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-mock/-/jest-mock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
       "dev": true,
       "dependencies": {
@@ -4482,7 +4482,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
       "dev": true,
       "engines": {
@@ -4499,7 +4499,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
       "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
       "dev": true,
       "engines": {
@@ -4508,7 +4508,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
       "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
       "dev": true,
       "dependencies": {
@@ -4524,7 +4524,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
       "dev": true,
       "dependencies": {
@@ -4538,7 +4538,7 @@
     },
     "node_modules/jest-runner": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runner/-/jest-runner-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
       "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
       "dev": true,
       "dependencies": {
@@ -4568,7 +4568,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
       "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
       "dev": true,
       "dependencies": {
@@ -4605,7 +4605,7 @@
     },
     "node_modules/jest-runtime/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -4614,7 +4614,7 @@
     },
     "node_modules/jest-serializer": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha1-5tfX75bTHouQeacUdUxdXFgojnM=",
       "dev": true,
       "engines": {
@@ -4623,7 +4623,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
       "dev": true,
       "dependencies": {
@@ -4647,7 +4647,7 @@
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "6.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true,
       "bin": {
@@ -4656,7 +4656,7 @@
     },
     "node_modules/jest-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-util/-/jest-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
       "dev": true,
       "dependencies": {
@@ -4679,7 +4679,7 @@
     },
     "node_modules/jest-util/node_modules/slash": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true,
       "engines": {
@@ -4688,7 +4688,7 @@
     },
     "node_modules/jest-validate": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-validate/-/jest-validate-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
       "dev": true,
       "dependencies": {
@@ -4705,7 +4705,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
       "dev": true,
       "dependencies": {
@@ -4723,7 +4723,7 @@
     },
     "node_modules/jest-worker": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-worker/-/jest-worker-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
       "dev": true,
       "dependencies": {
@@ -4736,7 +4736,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
       "dev": true,
       "dependencies": {
@@ -4767,13 +4767,13 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "node_modules/jsdom": {
       "version": "11.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsdom/-/jsdom-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "dependencies": {
@@ -4819,7 +4819,7 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true,
       "bin": {
@@ -4831,13 +4831,13 @@
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-schema/-/json-schema-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
@@ -4855,7 +4855,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -4873,7 +4873,7 @@
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsprim/-/jsprim-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "dependencies": {
@@ -4888,7 +4888,7 @@
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
       "engines": {
@@ -4897,7 +4897,7 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true,
       "engines": {
@@ -4906,14 +4906,14 @@
     },
     "node_modules/left-pad": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
       "deprecated": "use String.prototype.padStart()",
       "dev": true
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true,
       "engines": {
@@ -4935,13 +4935,13 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "dependencies": {
@@ -4956,7 +4956,7 @@
     },
     "node_modules/locate-path": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "dependencies": {
@@ -4969,19 +4969,19 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash/-/lodash-4.17.21.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "dependencies": {
@@ -4993,7 +4993,7 @@
     },
     "node_modules/make-dir": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "dependencies": {
@@ -5006,7 +5006,7 @@
     },
     "node_modules/make-dir/node_modules/pify": {
       "version": "4.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true,
       "engines": {
@@ -5015,7 +5015,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.11",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "dependencies": {
@@ -5024,7 +5024,7 @@
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true,
       "engines": {
@@ -5033,7 +5033,7 @@
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "dependencies": {
@@ -5045,13 +5045,13 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "node_modules/micromatch": {
       "version": "3.1.10",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "dependencies": {
@@ -5075,7 +5075,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.40.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
       "dev": true,
       "engines": {
@@ -5084,7 +5084,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.24",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
       "dev": true,
       "dependencies": {
@@ -5105,7 +5105,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimatch/-/minimatch-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
@@ -5117,13 +5117,13 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "dependencies": {
@@ -5136,7 +5136,7 @@
     },
     "node_modules/mixin-deep/node_modules/is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "dev": true,
       "dependencies": {
@@ -5148,7 +5148,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mkdirp/-/mkdirp-0.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
@@ -5172,14 +5172,14 @@
     },
     "node_modules/nan": {
       "version": "2.14.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nan/-/nan-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "dev": true,
       "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "dependencies": {
@@ -5207,7 +5207,7 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
@@ -5219,13 +5219,13 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node_modules/node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true,
       "engines": {
@@ -5234,7 +5234,7 @@
     },
     "node_modules/node-notifier": {
       "version": "5.4.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-notifier/-/node-notifier-5.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
       "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "dev": true,
       "dependencies": {
@@ -5247,7 +5247,7 @@
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "dependencies": {
@@ -5259,7 +5259,7 @@
     },
     "node_modules/normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "dependencies": {
@@ -5271,7 +5271,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "dependencies": {
@@ -5283,13 +5283,13 @@
     },
     "node_modules/nwsapi": {
       "version": "2.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nwsapi/-/nwsapi-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
       "integrity": "sha1-4AaoeNsjY2+OimfTPKDk7fYahC8=",
       "dev": true
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true,
       "engines": {
@@ -5298,7 +5298,7 @@
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "dependencies": {
@@ -5312,7 +5312,7 @@
     },
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "dependencies": {
@@ -5324,7 +5324,7 @@
     },
     "node_modules/object-copy/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -5336,13 +5336,13 @@
     },
     "node_modules/object-inspect": {
       "version": "1.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-inspect/-/object-inspect-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true,
       "engines": {
@@ -5351,7 +5351,7 @@
     },
     "node_modules/object-visit": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "dependencies": {
@@ -5363,7 +5363,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "dependencies": {
@@ -5378,7 +5378,7 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.entries/-/object.entries-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "dev": true,
       "dependencies": {
@@ -5393,7 +5393,7 @@
     },
     "node_modules/object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "dependencies": {
@@ -5406,7 +5406,7 @@
     },
     "node_modules/object.pick": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "dependencies": {
@@ -5418,7 +5418,7 @@
     },
     "node_modules/object.values": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.values/-/object.values-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "dependencies": {
@@ -5480,7 +5480,7 @@
     },
     "node_modules/p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "dependencies": {
@@ -5492,7 +5492,7 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true,
       "engines": {
@@ -5501,7 +5501,7 @@
     },
     "node_modules/p-limit": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "dependencies": {
@@ -5513,7 +5513,7 @@
     },
     "node_modules/p-locate": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "dependencies": {
@@ -5525,7 +5525,7 @@
     },
     "node_modules/p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true,
       "engines": {
@@ -5534,7 +5534,7 @@
     },
     "node_modules/p-try": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
       "engines": {
@@ -5555,7 +5555,7 @@
     },
     "node_modules/parse-json": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "dependencies": {
@@ -5567,13 +5567,13 @@
     },
     "node_modules/parse5": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "node_modules/pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true,
       "engines": {
@@ -5582,7 +5582,7 @@
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "engines": {
@@ -5615,13 +5615,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "dependencies": {
@@ -5633,13 +5633,13 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true,
       "engines": {
@@ -5648,7 +5648,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pirates/-/pirates-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "dev": true,
       "dependencies": {
@@ -5660,7 +5660,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "dependencies": {
@@ -5672,7 +5672,7 @@
     },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
       "dev": true,
       "dependencies": {
@@ -5681,13 +5681,13 @@
     },
     "node_modules/pn": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pn/-/pn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
       "dev": true
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true,
       "engines": {
@@ -5705,7 +5705,7 @@
     },
     "node_modules/prettier": {
       "version": "1.18.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prettier/-/prettier-1.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
       "dev": true,
       "bin": {
@@ -5729,7 +5729,7 @@
     },
     "node_modules/pretty-format": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pretty-format/-/pretty-format-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "dev": true,
       "dependencies": {
@@ -5744,7 +5744,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -5762,7 +5762,7 @@
     },
     "node_modules/prompts": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prompts/-/prompts-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
       "integrity": "sha1-+QHdKi3+4IA1nA4gBZskGI11rTU=",
       "dev": true,
       "dependencies": {
@@ -5775,13 +5775,13 @@
     },
     "node_modules/psl": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/psl/-/psl-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
       "integrity": "sha1-XdJhVs22n6H9uKsZkWZ9P4DO18I=",
       "dev": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "dependencies": {
@@ -5800,7 +5800,7 @@
     },
     "node_modules/qs": {
       "version": "6.5.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/qs/-/qs-6.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
       "engines": {
@@ -5809,13 +5809,13 @@
     },
     "node_modules/react-is": {
       "version": "16.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/react-is/-/react-is-16.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha1-IcqVYTmarQ/xp3AcAWg+jKmB7cs=",
       "dev": true
     },
     "node_modules/read-pkg": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "dependencies": {
@@ -5829,7 +5829,7 @@
     },
     "node_modules/read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "dependencies": {
@@ -5842,7 +5842,7 @@
     },
     "node_modules/realpath-native": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/realpath-native/-/realpath-native-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
       "dev": true,
       "dependencies": {
@@ -5854,7 +5854,7 @@
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "dependencies": {
@@ -5876,13 +5876,13 @@
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "node_modules/repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true,
       "engines": {
@@ -5891,7 +5891,7 @@
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true,
       "engines": {
@@ -5900,7 +5900,7 @@
     },
     "node_modules/request": {
       "version": "2.88.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request/-/request-2.88.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
@@ -5932,7 +5932,7 @@
     },
     "node_modules/request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "dependencies": {
@@ -5947,7 +5947,7 @@
     },
     "node_modules/request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
@@ -5965,13 +5965,13 @@
     },
     "node_modules/request/node_modules/punycode": {
       "version": "1.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "node_modules/request/node_modules/tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "dev": true,
       "dependencies": {
@@ -5984,7 +5984,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "engines": {
@@ -5993,13 +5993,13 @@
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "node_modules/resolve": {
       "version": "1.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "dependencies": {
@@ -6008,7 +6008,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "dependencies": {
@@ -6020,7 +6020,7 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true,
       "engines": {
@@ -6038,7 +6038,7 @@
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
@@ -6058,7 +6058,7 @@
     },
     "node_modules/ret": {
       "version": "0.1.15",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true,
       "engines": {
@@ -6079,7 +6079,7 @@
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/rsvp/-/rsvp-4.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
       "dev": true,
       "engines": {
@@ -6100,7 +6100,7 @@
     },
     "node_modules/run-node": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/run-node/-/run-node-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
       "integrity": "sha1-RrULlGoqotSUeuHYhumFb9nKvl4=",
       "dev": true,
       "bin": {
@@ -6124,13 +6124,13 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "dependencies": {
@@ -6145,7 +6145,7 @@
     },
     "node_modules/sane": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sane/-/sane-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
       "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "dev": true,
@@ -6169,7 +6169,7 @@
     },
     "node_modules/sax": {
       "version": "1.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
@@ -6184,19 +6184,19 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "dependencies": {
@@ -6211,7 +6211,7 @@
     },
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -6244,7 +6244,7 @@
     },
     "node_modules/shellwords": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true
     },
@@ -6256,13 +6256,13 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sisteransi/-/sisteransi-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
       "integrity": "sha1-mBaNYreeOl51jieuY8SgU9dI9Os=",
       "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true,
       "engines": {
@@ -6285,7 +6285,7 @@
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "dependencies": {
@@ -6304,7 +6304,7 @@
     },
     "node_modules/snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "dependencies": {
@@ -6318,7 +6318,7 @@
     },
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "dependencies": {
@@ -6330,7 +6330,7 @@
     },
     "node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
       "dev": true,
       "dependencies": {
@@ -6342,7 +6342,7 @@
     },
     "node_modules/snapdragon-node/node_modules/is-data-descriptor": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
       "dev": true,
       "dependencies": {
@@ -6354,7 +6354,7 @@
     },
     "node_modules/snapdragon-node/node_modules/is-descriptor": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
       "dev": true,
       "dependencies": {
@@ -6368,7 +6368,7 @@
     },
     "node_modules/snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "dependencies": {
@@ -6380,7 +6380,7 @@
     },
     "node_modules/snapdragon-util/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -6392,7 +6392,7 @@
     },
     "node_modules/snapdragon/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -6401,7 +6401,7 @@
     },
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "dependencies": {
@@ -6413,7 +6413,7 @@
     },
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "dependencies": {
@@ -6425,13 +6425,13 @@
     },
     "node_modules/snapdragon/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/snapdragon/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "engines": {
@@ -6440,7 +6440,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -6449,7 +6449,7 @@
     },
     "node_modules/source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
@@ -6463,7 +6463,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "dependencies": {
@@ -6473,14 +6473,14 @@
     },
     "node_modules/source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "dependencies": {
@@ -6490,13 +6490,13 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "dependencies": {
@@ -6506,13 +6506,13 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "node_modules/split-string": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "dependencies": {
@@ -6530,7 +6530,7 @@
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "dependencies": {
@@ -6555,7 +6555,7 @@
     },
     "node_modules/stack-utils": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stack-utils/-/stack-utils-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true,
       "engines": {
@@ -6564,7 +6564,7 @@
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "dependencies": {
@@ -6577,7 +6577,7 @@
     },
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "dependencies": {
@@ -6589,7 +6589,7 @@
     },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true,
       "engines": {
@@ -6598,7 +6598,7 @@
     },
     "node_modules/string-length": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "dependencies": {
@@ -6624,7 +6624,7 @@
     },
     "node_modules/string.prototype.trimleft": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha1-bMR/DX641isPNwFhFxWjlUWR1jQ=",
       "dev": true,
       "dependencies": {
@@ -6637,7 +6637,7 @@
     },
     "node_modules/string.prototype.trimright": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha1-Zp0WS+nfm291WfqOiZRbFopabFg=",
       "dev": true,
       "dependencies": {
@@ -6650,7 +6650,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "dependencies": {
@@ -6662,7 +6662,7 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true,
       "engines": {
@@ -6671,7 +6671,7 @@
     },
     "node_modules/strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "engines": {
@@ -6701,7 +6701,7 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
     },
@@ -6722,7 +6722,7 @@
     },
     "node_modules/table/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -6757,7 +6757,7 @@
     },
     "node_modules/test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "dependencies": {
@@ -6772,7 +6772,7 @@
     },
     "node_modules/test-exclude/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -6784,7 +6784,7 @@
     },
     "node_modules/test-exclude/node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "dependencies": {
@@ -6799,7 +6799,7 @@
     },
     "node_modules/test-exclude/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -6812,7 +6812,7 @@
     },
     "node_modules/test-exclude/node_modules/p-limit": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
       "dev": true,
       "dependencies": {
@@ -6824,7 +6824,7 @@
     },
     "node_modules/test-exclude/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -6836,7 +6836,7 @@
     },
     "node_modules/test-exclude/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -6845,7 +6845,7 @@
     },
     "node_modules/test-exclude/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "dependencies": {
@@ -6858,7 +6858,7 @@
     },
     "node_modules/test-exclude/node_modules/path-type": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "dependencies": {
@@ -6870,7 +6870,7 @@
     },
     "node_modules/test-exclude/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "engines": {
@@ -6879,7 +6879,7 @@
     },
     "node_modules/test-exclude/node_modules/read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "dependencies": {
@@ -6893,7 +6893,7 @@
     },
     "node_modules/test-exclude/node_modules/read-pkg-up": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
       "dev": true,
       "dependencies": {
@@ -6912,7 +6912,7 @@
     },
     "node_modules/throat": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
@@ -6936,13 +6936,13 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tmpl/-/tmpl-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "engines": {
@@ -6951,7 +6951,7 @@
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "dependencies": {
@@ -6963,7 +6963,7 @@
     },
     "node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "dependencies": {
@@ -6975,7 +6975,7 @@
     },
     "node_modules/to-regex": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "dependencies": {
@@ -6990,7 +6990,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "dependencies": {
@@ -7003,7 +7003,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "dependencies": {
@@ -7016,7 +7016,7 @@
     },
     "node_modules/tr46": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "dependencies": {
@@ -7025,7 +7025,7 @@
     },
     "node_modules/trim-right": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true,
       "engines": {
@@ -7040,7 +7040,7 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "dependencies": {
@@ -7052,7 +7052,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
@@ -7070,7 +7070,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/type-fest/-/type-fest-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
       "dev": true,
       "engines": {
@@ -7079,7 +7079,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uglify-js/-/uglify-js-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
       "dev": true,
       "optional": true,
@@ -7096,7 +7096,7 @@
     },
     "node_modules/union-value": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "dependencies": {
@@ -7111,7 +7111,7 @@
     },
     "node_modules/unset-value": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "dependencies": {
@@ -7124,7 +7124,7 @@
     },
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
       "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
       "dev": true,
       "dependencies": {
@@ -7138,7 +7138,7 @@
     },
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "dependencies": {
@@ -7150,7 +7150,7 @@
     },
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
       "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "dev": true,
       "engines": {
@@ -7168,14 +7168,14 @@
     },
     "node_modules/urix": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/use": {
       "version": "3.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/use/-/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true,
       "engines": {
@@ -7184,7 +7184,7 @@
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/util.promisify/-/util.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "dependencies": {
@@ -7194,7 +7194,7 @@
     },
     "node_modules/uuid": {
       "version": "3.3.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uuid/-/uuid-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
@@ -7204,7 +7204,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "dependencies": {
@@ -7214,7 +7214,7 @@
     },
     "node_modules/verror": {
       "version": "1.10.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "engines": [
@@ -7228,7 +7228,7 @@
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
@@ -7238,7 +7238,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "dependencies": {
@@ -7247,13 +7247,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "dependencies": {
@@ -7262,13 +7262,13 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "dependencies": {
@@ -7291,19 +7291,19 @@
     },
     "node_modules/which-module": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "dependencies": {
@@ -7317,7 +7317,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -7326,7 +7326,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "dependencies": {
@@ -7340,7 +7340,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "dependencies": {
@@ -7370,7 +7370,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "2.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
       "dev": true,
       "dependencies": {
@@ -7381,7 +7381,7 @@
     },
     "node_modules/ws": {
       "version": "5.2.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ws/-/ws-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
       "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "dependencies": {
@@ -7390,7 +7390,7 @@
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
@@ -7402,7 +7402,7 @@
     },
     "node_modules/yargs": {
       "version": "13.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/yargs/-/yargs-13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "dependencies": {
@@ -7430,7 +7430,7 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
@@ -7439,7 +7439,7 @@
     },
     "node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "dependencies": {
@@ -7451,7 +7451,7 @@
     },
     "node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "dependencies": {
@@ -7464,7 +7464,7 @@
     },
     "node_modules/yargs/node_modules/p-limit": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
       "dev": true,
       "dependencies": {
@@ -7476,7 +7476,7 @@
     },
     "node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "dependencies": {
@@ -7488,7 +7488,7 @@
     },
     "node_modules/yargs/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true,
       "engines": {
@@ -7497,7 +7497,7 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
       "dev": true,
       "dependencies": {
@@ -7511,7 +7511,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "dependencies": {
@@ -7534,7 +7534,7 @@
     },
     "@babel/core": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/core/-/core-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
       "integrity": "sha1-mwD3NVTt1nvryG34MD72eL49e0g=",
       "dev": true,
       "requires": {
@@ -7556,7 +7556,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.5.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
           "dev": true,
           "requires": {
@@ -7565,7 +7565,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -7573,7 +7573,7 @@
     },
     "@babel/generator": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/generator/-/generator-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
       "integrity": "sha1-4sIe+/0yk62BmiNZtEjwAr/f2lY=",
       "dev": true,
       "requires": {
@@ -7586,7 +7586,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -7594,7 +7594,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "requires": {
@@ -7605,7 +7605,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "requires": {
@@ -7614,13 +7614,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
       "dev": true
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
@@ -7629,7 +7629,7 @@
     },
     "@babel/helpers": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/helpers/-/helpers-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
       "integrity": "sha1-IZYdFsajw6tZcyXDTEZcCIfTHG4=",
       "dev": true,
       "requires": {
@@ -7651,13 +7651,13 @@
     },
     "@babel/parser": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/parser/-/parser-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
       "integrity": "sha1-PgXQZHQyqDJsso0N4DiVrlpX85s=",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "dev": true,
       "requires": {
@@ -7666,7 +7666,7 @@
     },
     "@babel/template": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/template/-/template-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
       "integrity": "sha1-fwFZx/UBIjDa1kzKQuyb21yVNuY=",
       "dev": true,
       "requires": {
@@ -7677,7 +7677,7 @@
     },
     "@babel/traverse": {
       "version": "7.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/traverse/-/traverse-7.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
       "integrity": "sha1-OJOR1RD3m+fOLd1nF75m0/7UtRY=",
       "dev": true,
       "requires": {
@@ -7694,7 +7694,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.5.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
           "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
           "dev": true,
           "requires": {
@@ -7705,7 +7705,7 @@
     },
     "@babel/types": {
       "version": "7.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@babel/types/-/types-7.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
       "integrity": "sha1-U6vzMIrdOsKiiE1TkVHFfEs6xkg=",
       "dev": true,
       "requires": {
@@ -7716,7 +7716,7 @@
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
       "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
       "dev": true,
       "requires": {
@@ -7726,7 +7726,7 @@
     },
     "@jest/console": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/console/-/console-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
       "dev": true,
       "requires": {
@@ -7737,7 +7737,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -7745,7 +7745,7 @@
     },
     "@jest/core": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/core/-/core-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
       "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
       "dev": true,
       "requires": {
@@ -7781,19 +7781,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -7804,7 +7804,7 @@
     },
     "@jest/environment": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/environment/-/environment-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
       "dev": true,
       "requires": {
@@ -7816,7 +7816,7 @@
     },
     "@jest/fake-timers": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
       "dev": true,
       "requires": {
@@ -7827,7 +7827,7 @@
     },
     "@jest/reporters": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/reporters/-/reporters-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
       "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
       "dev": true,
       "requires": {
@@ -7856,7 +7856,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -7864,7 +7864,7 @@
     },
     "@jest/source-map": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/source-map/-/source-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
       "dev": true,
       "requires": {
@@ -7875,7 +7875,7 @@
     },
     "@jest/test-result": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-result/-/test-result-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
       "dev": true,
       "requires": {
@@ -7886,7 +7886,7 @@
     },
     "@jest/test-sequencer": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
       "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
       "dev": true,
       "requires": {
@@ -7898,7 +7898,7 @@
     },
     "@jest/transform": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/transform/-/transform-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
       "dev": true,
       "requires": {
@@ -7922,7 +7922,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -7930,7 +7930,7 @@
     },
     "@jest/types": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@jest/types/-/types-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "dev": true,
       "requires": {
@@ -7941,7 +7941,7 @@
     },
     "@types/babel__core": {
       "version": "7.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
       "integrity": "sha1-5EHqffY80IDfzQKrGZ5tFqc1/DA=",
       "dev": true,
       "requires": {
@@ -7954,7 +7954,7 @@
     },
     "@types/babel__generator": {
       "version": "7.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
       "dev": true,
       "requires": {
@@ -7963,7 +7963,7 @@
     },
     "@types/babel__template": {
       "version": "7.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
       "dev": true,
       "requires": {
@@ -7973,7 +7973,7 @@
     },
     "@types/babel__traverse": {
       "version": "7.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
       "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
       "dev": true,
       "requires": {
@@ -7982,13 +7982,13 @@
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
       "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
       "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
       "dev": true,
       "requires": {
@@ -7997,7 +7997,7 @@
     },
     "@types/istanbul-reports": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
       "dev": true,
       "requires": {
@@ -8007,19 +8007,19 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
       "dev": true
     },
     "@types/yargs": {
       "version": "13.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs/-/yargs-13.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
       "integrity": "sha1-pkZ0/AFJV07NkLp0bpMrWl97NlM=",
       "dev": true,
       "requires": {
@@ -8028,13 +8028,13 @@
     },
     "@types/yargs-parser": {
       "version": "13.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha1-xWOqGS85NQodGNo2xajaOCu9gig=",
       "dev": true
     },
     "abab": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/abab/-/abab-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
       "integrity": "sha1-P6F3lwMrcUEOw3LhFmj0tP/IaoI=",
       "dev": true
     },
@@ -8046,7 +8046,7 @@
     },
     "acorn-globals": {
       "version": "4.3.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
       "integrity": "sha1-n6GSat3BHJcwjE5m163Q1Awycuc=",
       "dev": true,
       "requires": {
@@ -8063,13 +8063,13 @@
     },
     "acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
@@ -8087,7 +8087,7 @@
     },
     "ansi-regex": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
       "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "dev": true
     },
@@ -8102,7 +8102,7 @@
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/anymatch/-/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
@@ -8121,31 +8121,31 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
@@ -8155,13 +8155,13 @@
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
@@ -8170,13 +8170,13 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -8188,37 +8188,37 @@
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "babel-jest": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-jest/-/babel-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "dev": true,
       "requires": {
@@ -8233,7 +8233,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -8241,7 +8241,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
       "dev": true,
       "requires": {
@@ -8253,7 +8253,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -8262,7 +8262,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -8272,7 +8272,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -8281,7 +8281,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -8290,7 +8290,7 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         }
@@ -8298,7 +8298,7 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "dev": true,
       "requires": {
@@ -8307,7 +8307,7 @@
     },
     "babel-preset-jest": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "dev": true,
       "requires": {
@@ -8323,7 +8323,7 @@
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
@@ -8338,7 +8338,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -8347,7 +8347,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -8356,7 +8356,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -8365,7 +8365,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -8378,7 +8378,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -8397,7 +8397,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
@@ -8415,7 +8415,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -8426,13 +8426,13 @@
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
       "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
       "dev": true,
       "requires": {
@@ -8441,7 +8441,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -8449,7 +8449,7 @@
     },
     "bser": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/bser/-/bser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
       "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
       "dev": true,
       "requires": {
@@ -8458,13 +8458,13 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -8481,7 +8481,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -8490,7 +8490,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -8498,7 +8498,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -8513,13 +8513,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/capture-exit/-/capture-exit-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
       "dev": true,
       "requires": {
@@ -8528,7 +8528,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -8551,13 +8551,13 @@
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -8569,7 +8569,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -8595,7 +8595,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
@@ -8606,13 +8606,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -8623,7 +8623,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -8634,13 +8634,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -8665,7 +8665,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
@@ -8679,7 +8679,7 @@
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
@@ -8691,19 +8691,19 @@
     },
     "confusing-browser-globals": {
       "version": "1.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
       "integrity": "sha1-k//sH4Km4r8rw2dpzDqS+iDlAvM=",
       "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -8712,19 +8712,19 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "requires": {
@@ -8736,7 +8736,7 @@
       "dependencies": {
         "import-fresh": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-fresh/-/import-fresh-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
           "requires": {
@@ -8746,7 +8746,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -8756,7 +8756,7 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -8777,13 +8777,13 @@
     },
     "cssom": {
       "version": "0.3.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssom/-/cssom-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
       "dev": true
     },
     "cssstyle": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/cssstyle/-/cssstyle-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
       "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "dev": true,
       "requires": {
@@ -8792,7 +8792,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -8801,7 +8801,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "dev": true,
       "requires": {
@@ -8812,7 +8812,7 @@
       "dependencies": {
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "dev": true,
           "requires": {
@@ -8834,13 +8834,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
       "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
@@ -8852,7 +8852,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -8861,7 +8861,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
@@ -8871,7 +8871,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -8880,7 +8880,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -8889,7 +8889,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -8902,19 +8902,19 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
       "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
       "dev": true
     },
@@ -8929,7 +8929,7 @@
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "dev": true,
       "requires": {
@@ -8938,7 +8938,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -8954,7 +8954,7 @@
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
@@ -8963,7 +8963,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -8972,7 +8972,7 @@
     },
     "es-abstract": {
       "version": "1.14.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-abstract/-/es-abstract-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
       "integrity": "sha1-fOEI+tgwaMh4PDzfYuUE4ITYxJc=",
       "dev": true,
       "requires": {
@@ -8990,7 +8990,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "requires": {
@@ -9007,7 +9007,7 @@
     },
     "escodegen": {
       "version": "1.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/escodegen/-/escodegen-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
       "dev": true,
       "requires": {
@@ -9020,7 +9020,7 @@
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/esprima/-/esprima-3.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
@@ -9072,7 +9072,7 @@
     },
     "eslint-config-airbnb-base": {
       "version": "13.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
       "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
       "dev": true,
       "requires": {
@@ -9092,7 +9092,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "requires": {
@@ -9102,7 +9102,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9111,7 +9111,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9119,7 +9119,7 @@
     },
     "eslint-module-utils": {
       "version": "2.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
       "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
       "dev": true,
       "requires": {
@@ -9129,7 +9129,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9138,7 +9138,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9146,7 +9146,7 @@
     },
     "eslint-plugin-import": {
       "version": "2.18.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
       "dev": true,
       "requires": {
@@ -9165,7 +9165,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9174,7 +9174,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -9184,7 +9184,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9273,13 +9273,13 @@
     },
     "exec-sh": {
       "version": "0.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exec-sh/-/exec-sh-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
       "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
       "dev": true
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
@@ -9294,13 +9294,13 @@
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -9315,7 +9315,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9324,7 +9324,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -9333,7 +9333,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9342,7 +9342,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9350,7 +9350,7 @@
     },
     "expect": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/expect/-/expect-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
       "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
       "dev": true,
       "requires": {
@@ -9364,13 +9364,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -9380,7 +9380,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -9402,7 +9402,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -9418,7 +9418,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -9427,7 +9427,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9436,7 +9436,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -9445,7 +9445,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -9454,7 +9454,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -9467,13 +9467,13 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
@@ -9497,7 +9497,7 @@
     },
     "fb-watchman": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
@@ -9524,7 +9524,7 @@
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -9536,7 +9536,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9547,7 +9547,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -9573,19 +9573,19 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
@@ -9596,7 +9596,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -9611,7 +9611,7 @@
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/fsevents/-/fsevents-1.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
       "dev": true,
       "optional": true,
@@ -10159,7 +10159,7 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
@@ -10171,7 +10171,7 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
@@ -10183,7 +10183,7 @@
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
@@ -10192,13 +10192,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -10227,19 +10227,19 @@
     },
     "graceful-fs": {
       "version": "4.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
       "dev": true
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "handlebars": {
       "version": "4.7.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/handlebars/-/handlebars-4.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
@@ -10252,13 +10252,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
@@ -10268,7 +10268,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has/-/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -10283,13 +10283,13 @@
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -10300,7 +10300,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -10310,7 +10310,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -10321,13 +10321,13 @@
     },
     "hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
       "dev": true,
       "requires": {
@@ -10336,7 +10336,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -10347,7 +10347,7 @@
     },
     "husky": {
       "version": "2.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/husky/-/husky-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-2.7.0.tgz",
       "integrity": "sha1-wKmmo7URRiJOEbugtGu6VG5GHQU=",
       "dev": true,
       "requires": {
@@ -10365,7 +10365,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -10374,13 +10374,13 @@
         },
         "get-stdin": {
           "version": "7.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/get-stdin/-/get-stdin-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
           "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY=",
           "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -10390,7 +10390,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -10399,7 +10399,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -10408,13 +10408,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "parse-json": {
           "version": "5.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
           "dev": true,
           "requires": {
@@ -10426,7 +10426,7 @@
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
           "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
           "dev": true,
           "requires": {
@@ -10435,7 +10435,7 @@
           "dependencies": {
             "find-up": {
               "version": "4.1.0",
-              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
               "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
               "dev": true,
               "requires": {
@@ -10445,7 +10445,7 @@
             },
             "locate-path": {
               "version": "5.0.0",
-              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-5.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
               "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
               "dev": true,
               "requires": {
@@ -10454,7 +10454,7 @@
             },
             "p-locate": {
               "version": "4.1.0",
-              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
               "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
               "dev": true,
               "requires": {
@@ -10463,7 +10463,7 @@
             },
             "path-exists": {
               "version": "4.0.0",
-              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
               "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
               "dev": true
             }
@@ -10471,7 +10471,7 @@
         },
         "read-pkg": {
           "version": "5.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
           "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
           "dev": true,
           "requires": {
@@ -10510,7 +10510,7 @@
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/import-local/-/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
@@ -10520,7 +10520,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -10529,7 +10529,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -10539,7 +10539,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -10548,7 +10548,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -10557,13 +10557,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
           "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
@@ -10617,7 +10617,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
@@ -10634,7 +10634,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -10643,7 +10643,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -10652,7 +10652,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -10663,25 +10663,25 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "dev": true,
       "requires": {
@@ -10690,7 +10690,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -10699,7 +10699,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -10710,13 +10710,13 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
@@ -10727,7 +10727,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
@@ -10735,13 +10735,13 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
@@ -10753,13 +10753,13 @@
     },
     "is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -10768,7 +10768,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -10779,7 +10779,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
@@ -10794,7 +10794,7 @@
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -10803,13 +10803,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "requires": {
@@ -10818,25 +10818,25 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -10848,25 +10848,25 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "requires": {
@@ -10881,7 +10881,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -10889,7 +10889,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "requires": {
@@ -10900,7 +10900,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -10911,7 +10911,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "requires": {
@@ -10924,7 +10924,7 @@
     },
     "istanbul-reports": {
       "version": "2.2.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
       "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
       "dev": true,
       "requires": {
@@ -10933,7 +10933,7 @@
     },
     "jest-changed-files": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
       "dev": true,
       "requires": {
@@ -10944,7 +10944,7 @@
     },
     "jest-cli": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-cli/-/jest-cli-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
       "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
       "dev": true,
       "requires": {
@@ -10965,7 +10965,7 @@
     },
     "jest-config": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-config/-/jest-config-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
       "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
       "dev": true,
       "requires": {
@@ -10990,7 +10990,7 @@
     },
     "jest-diff": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-diff/-/jest-diff-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "dev": true,
       "requires": {
@@ -11002,7 +11002,7 @@
     },
     "jest-docblock": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
       "dev": true,
       "requires": {
@@ -11011,7 +11011,7 @@
     },
     "jest-each": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-each/-/jest-each-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
       "dev": true,
       "requires": {
@@ -11024,7 +11024,7 @@
     },
     "jest-environment-jsdom": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
       "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
       "dev": true,
       "requires": {
@@ -11038,7 +11038,7 @@
     },
     "jest-environment-node": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
       "dev": true,
       "requires": {
@@ -11051,13 +11051,13 @@
     },
     "jest-get-type": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
       "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
       "dev": true
     },
     "jest-haste-map": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
       "dev": true,
       "requires": {
@@ -11077,7 +11077,7 @@
     },
     "jest-jasmine2": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
       "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
       "dev": true,
       "requires": {
@@ -11101,7 +11101,7 @@
     },
     "jest-leak-detector": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
       "dev": true,
       "requires": {
@@ -11111,7 +11111,7 @@
     },
     "jest-matcher-utils": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
       "dev": true,
       "requires": {
@@ -11123,7 +11123,7 @@
     },
     "jest-message-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
       "dev": true,
       "requires": {
@@ -11139,7 +11139,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -11147,7 +11147,7 @@
     },
     "jest-mock": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-mock/-/jest-mock-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
       "dev": true,
       "requires": {
@@ -11156,20 +11156,20 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
       "dev": true,
       "requires": {}
     },
     "jest-regex-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
       "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
       "dev": true
     },
     "jest-resolve": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
       "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
       "dev": true,
       "requires": {
@@ -11182,7 +11182,7 @@
     },
     "jest-resolve-dependencies": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
       "dev": true,
       "requires": {
@@ -11193,7 +11193,7 @@
     },
     "jest-runner": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runner/-/jest-runner-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
       "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
       "dev": true,
       "requires": {
@@ -11220,7 +11220,7 @@
     },
     "jest-runtime": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
       "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
       "dev": true,
       "requires": {
@@ -11251,7 +11251,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -11259,13 +11259,13 @@
     },
     "jest-serializer": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha1-5tfX75bTHouQeacUdUxdXFgojnM=",
       "dev": true
     },
     "jest-snapshot": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
       "dev": true,
       "requires": {
@@ -11286,7 +11286,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -11294,7 +11294,7 @@
     },
     "jest-util": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-util/-/jest-util-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
       "dev": true,
       "requires": {
@@ -11314,7 +11314,7 @@
       "dependencies": {
         "slash": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
           "dev": true
         }
@@ -11322,7 +11322,7 @@
     },
     "jest-validate": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-validate/-/jest-validate-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
       "dev": true,
       "requires": {
@@ -11336,7 +11336,7 @@
     },
     "jest-watcher": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
       "dev": true,
       "requires": {
@@ -11351,7 +11351,7 @@
     },
     "jest-worker": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jest-worker/-/jest-worker-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
       "dev": true,
       "requires": {
@@ -11361,7 +11361,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/supports-color/-/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -11388,13 +11388,13 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsdom/-/jsdom-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
@@ -11436,19 +11436,19 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-schema/-/json-schema-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
@@ -11466,7 +11466,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -11478,7 +11478,7 @@
     },
     "jsprim": {
       "version": "1.4.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/jsprim/-/jsprim-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
@@ -11490,25 +11490,25 @@
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
       "version": "3.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
       "dev": true
     },
     "leven": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true
     },
@@ -11524,13 +11524,13 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -11542,7 +11542,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -11552,19 +11552,19 @@
     },
     "lodash": {
       "version": "4.17.21",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash/-/lodash-4.17.21.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -11573,7 +11573,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/make-dir/-/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
@@ -11583,7 +11583,7 @@
       "dependencies": {
         "pify": {
           "version": "4.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
@@ -11591,7 +11591,7 @@
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
@@ -11600,13 +11600,13 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -11615,13 +11615,13 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
@@ -11642,13 +11642,13 @@
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-db/-/mime-db-1.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mime-types/-/mime-types-2.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
       "dev": true,
       "requires": {
@@ -11663,7 +11663,7 @@
     },
     "minimatch": {
       "version": "3.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimatch/-/minimatch-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
@@ -11672,13 +11672,13 @@
     },
     "minimist": {
       "version": "1.2.8",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
@@ -11688,7 +11688,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -11699,7 +11699,7 @@
     },
     "mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/mkdirp/-/mkdirp-0.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
@@ -11720,14 +11720,14 @@
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nan/-/nan-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -11752,7 +11752,7 @@
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
@@ -11764,19 +11764,19 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
     "node-notifier": {
       "version": "5.4.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/node-notifier/-/node-notifier-5.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
       "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
       "dev": true,
       "requires": {
@@ -11789,7 +11789,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -11801,7 +11801,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -11810,7 +11810,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -11819,19 +11819,19 @@
     },
     "nwsapi": {
       "version": "2.1.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/nwsapi/-/nwsapi-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
       "integrity": "sha1-4AaoeNsjY2+OimfTPKDk7fYahC8=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -11842,7 +11842,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -11851,7 +11851,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -11862,19 +11862,19 @@
     },
     "object-inspect": {
       "version": "1.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-inspect/-/object-inspect-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
       "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -11883,7 +11883,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
@@ -11895,7 +11895,7 @@
     },
     "object.entries": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.entries/-/object.entries-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "dev": true,
       "requires": {
@@ -11907,7 +11907,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
@@ -11917,7 +11917,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -11926,7 +11926,7 @@
     },
     "object.values": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/object.values/-/object.values-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "requires": {
@@ -11976,7 +11976,7 @@
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
@@ -11985,13 +11985,13 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
@@ -12000,7 +12000,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -12009,13 +12009,13 @@
     },
     "p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
@@ -12030,7 +12030,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -12039,19 +12039,19 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
@@ -12075,13 +12075,13 @@
     },
     "path-parse": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
@@ -12090,19 +12090,19 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pirates/-/pirates-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "dev": true,
       "requires": {
@@ -12111,7 +12111,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -12120,7 +12120,7 @@
     },
     "please-upgrade-node": {
       "version": "3.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha1-rt3T+ZTJM+StmLmdmlVu+g4v6UI=",
       "dev": true,
       "requires": {
@@ -12129,13 +12129,13 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pn/-/pn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
       "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -12147,7 +12147,7 @@
     },
     "prettier": {
       "version": "1.18.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prettier/-/prettier-1.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
       "dev": true
     },
@@ -12162,7 +12162,7 @@
     },
     "pretty-format": {
       "version": "24.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pretty-format/-/pretty-format-24.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "dev": true,
       "requires": {
@@ -12174,7 +12174,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         }
@@ -12188,7 +12188,7 @@
     },
     "prompts": {
       "version": "2.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/prompts/-/prompts-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
       "integrity": "sha1-+QHdKi3+4IA1nA4gBZskGI11rTU=",
       "dev": true,
       "requires": {
@@ -12198,13 +12198,13 @@
     },
     "psl": {
       "version": "1.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/psl/-/psl-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
       "integrity": "sha1-XdJhVs22n6H9uKsZkWZ9P4DO18I=",
       "dev": true
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
@@ -12220,19 +12220,19 @@
     },
     "qs": {
       "version": "6.5.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/qs/-/qs-6.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
     "react-is": {
       "version": "16.9.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/react-is/-/react-is-16.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha1-IcqVYTmarQ/xp3AcAWg+jKmB7cs=",
       "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
@@ -12243,7 +12243,7 @@
     },
     "read-pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
@@ -12253,7 +12253,7 @@
     },
     "realpath-native": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/realpath-native/-/realpath-native-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
       "dev": true,
       "requires": {
@@ -12262,7 +12262,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -12278,25 +12278,25 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request/-/request-2.88.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "dev": true,
       "requires": {
@@ -12324,13 +12324,13 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "dev": true,
           "requires": {
@@ -12342,7 +12342,7 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "requires": {
@@ -12351,7 +12351,7 @@
     },
     "request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "dev": true,
       "requires": {
@@ -12362,19 +12362,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "resolve": {
       "version": "1.12.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve/-/resolve-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "requires": {
@@ -12383,7 +12383,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -12392,7 +12392,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -12406,7 +12406,7 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
@@ -12422,7 +12422,7 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
@@ -12437,7 +12437,7 @@
     },
     "rsvp": {
       "version": "4.8.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/rsvp/-/rsvp-4.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ=",
       "dev": true
     },
@@ -12452,7 +12452,7 @@
     },
     "run-node": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/run-node/-/run-node-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
       "integrity": "sha1-RrULlGoqotSUeuHYhumFb9nKvl4=",
       "dev": true
     },
@@ -12467,13 +12467,13 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -12488,7 +12488,7 @@
     },
     "sane": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sane/-/sane-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
       "dev": true,
       "requires": {
@@ -12505,7 +12505,7 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
@@ -12517,19 +12517,19 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
@@ -12541,7 +12541,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -12567,7 +12567,7 @@
     },
     "shellwords": {
       "version": "0.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/shellwords/-/shellwords-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true
     },
@@ -12579,13 +12579,13 @@
     },
     "sisteransi": {
       "version": "1.0.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sisteransi/-/sisteransi-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
       "integrity": "sha1-mBaNYreeOl51jieuY8SgU9dI9Os=",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true
     },
@@ -12602,7 +12602,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -12618,7 +12618,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -12627,7 +12627,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -12636,7 +12636,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -12645,13 +12645,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -12659,7 +12659,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
@@ -12670,7 +12670,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -12679,7 +12679,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -12688,7 +12688,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -12697,7 +12697,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -12710,7 +12710,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -12719,7 +12719,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -12730,13 +12730,13 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
@@ -12749,7 +12749,7 @@
     },
     "source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "requires": {
@@ -12759,13 +12759,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -12775,13 +12775,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -12791,13 +12791,13 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -12812,7 +12812,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
@@ -12829,13 +12829,13 @@
     },
     "stack-utils": {
       "version": "1.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stack-utils/-/stack-utils-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -12845,7 +12845,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -12856,13 +12856,13 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "string-length": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
@@ -12882,7 +12882,7 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha1-bMR/DX641isPNwFhFxWjlUWR1jQ=",
       "dev": true,
       "requires": {
@@ -12892,7 +12892,7 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha1-Zp0WS+nfm291WfqOiZRbFopabFg=",
       "dev": true,
       "requires": {
@@ -12902,7 +12902,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
@@ -12911,13 +12911,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12938,7 +12938,7 @@
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
     },
@@ -12956,7 +12956,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
@@ -12984,7 +12984,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/test-exclude/-/test-exclude-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "requires": {
@@ -12996,7 +12996,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -13005,7 +13005,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -13017,7 +13017,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -13027,7 +13027,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -13036,7 +13036,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -13045,13 +13045,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -13061,7 +13061,7 @@
         },
         "path-type": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/path-type/-/path-type-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
           "dev": true,
           "requires": {
@@ -13070,13 +13070,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -13087,7 +13087,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
           "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
           "dev": true,
           "requires": {
@@ -13105,7 +13105,7 @@
     },
     "throat": {
       "version": "4.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
@@ -13126,19 +13126,19 @@
     },
     "tmpl": {
       "version": "1.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tmpl/-/tmpl-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -13147,7 +13147,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -13158,7 +13158,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -13170,7 +13170,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -13180,7 +13180,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "requires": {
@@ -13190,7 +13190,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -13199,7 +13199,7 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -13211,7 +13211,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -13220,7 +13220,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
@@ -13235,13 +13235,13 @@
     },
     "type-fest": {
       "version": "0.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/type-fest/-/type-fest-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.6.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uglify-js/-/uglify-js-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
       "dev": true,
       "optional": true,
@@ -13252,7 +13252,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
@@ -13264,7 +13264,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -13274,7 +13274,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -13285,7 +13285,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -13296,7 +13296,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -13313,19 +13313,19 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/use/-/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/util.promisify/-/util.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
@@ -13335,13 +13335,13 @@
     },
     "uuid": {
       "version": "3.3.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/uuid/-/uuid-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -13351,7 +13351,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -13362,7 +13362,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
@@ -13371,7 +13371,7 @@
     },
     "walker": {
       "version": "1.0.7",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
@@ -13380,13 +13380,13 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "requires": {
@@ -13395,13 +13395,13 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
@@ -13421,19 +13421,19 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
@@ -13444,13 +13444,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -13461,7 +13461,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -13487,7 +13487,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.1",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
       "dev": true,
       "requires": {
@@ -13498,7 +13498,7 @@
     },
     "ws": {
       "version": "5.2.3",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ws/-/ws-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
       "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "dev": true,
       "requires": {
@@ -13507,7 +13507,7 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
@@ -13519,7 +13519,7 @@
     },
     "yargs": {
       "version": "13.3.0",
-      "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/yargs/-/yargs-13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "requires": {
@@ -13537,13 +13537,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
           "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -13552,7 +13552,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -13562,7 +13562,7 @@
         },
         "p-limit": {
           "version": "2.2.1",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-limit/-/p-limit-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
           "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
           "dev": true,
           "requires": {
@@ -13571,7 +13571,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -13580,13 +13580,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/p-try/-/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -13597,7 +13597,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://bluescape.jfrog.io/artifactory/api/npm/bluescape-repo/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {


### PR DESCRIPTION
Now supports passing in `--auth-type legacy` and having that flow through to the `npm login` command.